### PR TITLE
One hundred percent shell

### DIFF
--- a/tests/Containerfile.test
+++ b/tests/Containerfile.test
@@ -1,0 +1,23 @@
+FROM alpine:3.21 AS builder
+
+RUN apk add --no-cache gcc musl-dev make curl
+
+RUN curl -fsSL https://ftp.gnu.org/gnu/bash/bash-4.4.tar.gz | tar xz \
+    && cd bash-4.4 \
+    && CFLAGS="-Wno-error=implicit-function-declaration" \
+       ./configure --prefix=/opt/bash-4.4 --without-bash-malloc --disable-nls \
+    && make \
+    && make install \
+    && strip /opt/bash-4.4/bin/bash
+
+FROM alpine:3.21
+
+# ncurses for tput colors
+RUN apk add --no-cache dash mksh zsh ncurses
+
+COPY --from=builder /opt/bash-4.4/bin/bash /usr/local/bin/bash
+
+RUN ln -s /bin/busybox /usr/local/bin/ash \
+    && ln -s /bin/mksh /usr/local/bin/ksh
+
+WORKDIR /shifu


### PR DESCRIPTION
I'd really like the repo summary to show 100% shell. Maybe adding a fake file extension to the containerfile will do that.