### PR TITLE
Prevent case statement eval errors and infinite loops

### DIFF
--- a/shifu
+++ b/shifu
@@ -691,21 +691,14 @@ _shifu_error() {
 }
 
 _shifu_case_loop_error() {
-  echo "shifu: case statement loop detected (no progress made)"
-  echo "A case pattern is missing 'shift' or 'break'. Check your argument definitions."
-  [ "${SHIFU_DEBUG_CASE:-0}" = 1 ] && {
-    echo "Case statement:"
-    printf '%s\n' "$shifu_case_stmt"
-  } || echo "Set SHIFU_DEBUG_CASE=1 to see the case statement"
+  echo "Internal error"
+  [ "${SHIFU_DEBUG_CASE:-0}" = 1 ] && printf '%s\n' "$shifu_case_stmt"
   exit 1
 }
 
 _shifu_case_eval_error() {
-  echo "shifu: case statement syntax error"
-  [ "${SHIFU_DEBUG_CASE:-0}" = 1 ] && {
-    echo "Case statement:"
-    printf '%s\n' "$shifu_case_stmt"
-  } || echo "Set SHIFU_DEBUG_CASE=1 to see the case statement"
+  echo "Internal error"
+  [ "${SHIFU_DEBUG_CASE:-0}" = 1 ] && printf '%s\n' "$shifu_case_stmt"
   exit 1
 }
 

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -782,31 +782,27 @@ test_shifu_set_variable() {
 test_shifu_case_loop_error() {
   shifu_case_stmt="case \"\$1\" in *) ;; esac"
   actual=$(SHIFU_DEBUG_CASE=0 _shifu_case_loop_error 2>&1)
-  exit_code=$?
-  shifu_assert_non_zero exit_code $exit_code
-  shifu_assert_string_contains message "$actual" "case statement loop detected"
-  shifu_assert_string_contains hint "$actual" "SHIFU_DEBUG_CASE=1"
+  shifu_assert_non_zero exit_code $?
+  shifu_assert_strings_equal message "Internal error" "$actual"
 }
 
 test_shifu_case_loop_error_with_debug() {
-  shifu_case_stmt="case \"\$1\" in test-pattern) ;; esac"
-  actual=$(SHIFU_DEBUG_CASE=1 _shifu_case_loop_error 2>&1)
-  shifu_assert_string_contains case_stmt "$actual" "test-pattern"
+  shifu_case_stmt='case "$1" in test-pattern) ;; esac'
+  actual=$(_shifu_case_loop_error 2>&1)
+  shifu_assert_string_contains output "$actual" 'case "$1" in test-pattern) ;; esac'
 }
 
 test_shifu_case_eval_error() {
   shifu_case_stmt="case \"\$1\" in bad-syntax"
   actual=$(SHIFU_DEBUG_CASE=0 _shifu_case_eval_error 2>&1)
-  exit_code=$?
-  shifu_assert_non_zero exit_code $exit_code
-  shifu_assert_string_contains message "$actual" "case statement syntax error"
-  shifu_assert_string_contains hint "$actual" "SHIFU_DEBUG_CASE=1"
+  shifu_assert_non_zero exit_code $?
+  shifu_assert_strings_equal message "Internal error" "$actual"
 }
 
 test_shifu_case_eval_error_with_debug() {
-  shifu_case_stmt="case \"\$1\" in test-syntax-pattern"
-  actual=$(SHIFU_DEBUG_CASE=1 _shifu_case_eval_error 2>&1)
-  shifu_assert_string_contains case_stmt "$actual" "test-syntax-pattern"
+  shifu_case_stmt='case "$1" in test-syntax-pattern'
+  actual=$(_shifu_case_eval_error 2>&1)
+  shifu_assert_string_contains output "$actual" 'case "$1" in test-syntax-pattern'
 }
 
 test_shifu_complete_bad_case_stmt_exits_silently() {


### PR DESCRIPTION
There are still edge cases where issues with case statement construction leads to issues in evaluating them. Since they happen in loops these can frequently cause infinite error messages getting emitted. This PR implements a strategy to catch those errors and prevent infinite loops.