### PR TITLE
Refactor cmd_{opt,arg} dispatch indirection

### DIFF
--- a/shifu
+++ b/shifu
@@ -130,23 +130,31 @@ shifu_cmd_func() {
 }
 
 shifu_cmd_optb() {
-  _shifu_cmd_opt_dispatch _shifu_cmd_optb "$@"
+  _shifu_cmd_get_arg_scope "$@"
+  shift $?
+  _shifu_cmd_optb "$@"
 }
 
 shifu_cmd_optd() {
-  _shifu_cmd_opt_dispatch _shifu_cmd_optd "$@"
+  _shifu_cmd_get_arg_scope "$@"
+  shift $?
+  _shifu_cmd_optd "$@"
 }
 
 shifu_cmd_optr() {
-  _shifu_cmd_opt_dispatch _shifu_cmd_optr "$@"
+  _shifu_cmd_get_arg_scope "$@"
+  shift $?
+  _shifu_cmd_optr "$@"
 }
 
 shifu_cmd_argr() {
-  _shifu_cmd_arg_dispatch _shifu_cmd_argr "$@"
+  _shifu_cmd_require_leaf
+  _shifu_cmd_argr "$@"
 }
 
 shifu_cmd_args() {
-  _shifu_cmd_arg_dispatch _shifu_cmd_args "$@"
+  _shifu_cmd_require_leaf
+  _shifu_cmd_args "$@"
 }
 
 shifu_cmd_cpte() {
@@ -487,205 +495,210 @@ _shifu_opt_build_comp_defer_parse() {
   ' '|' "$@"
 }
 
-_shifu_cmd_optb_help() {
-  _shifu_opt_help_parse "$@"
-  shift $shifu_opt_count
-  _shifu_error_if_invalid_arg_order "$1" $shifu_help_stage
-  shifu_help_options="$shifu_help_options\n    $4\n    Default: ${2:-empty}, set: $3"
-}
-
-_shifu_cmd_optb_build_now() {
-  _shifu_opt_case_parse "$@"
-  shift $shifu_opt_count
-  _shifu_error_if_invalid_arg_order "$1" $shifu_parse_stage
-  _shifu_set_variable "$1" "$2"
-  shifu_case_stmt="$shifu_case_stmt) $1=$3; shift; _shifu_ack_arg ;;"
-}
-
-_shifu_cmd_optb_build_defer() {
-  _shifu_opt_defer_parse "$@"
-  shift $shifu_opt_count
-  _shifu_set_variable "$1" "$2"
-  shifu_defer_case="${shifu_defer_case:-}) $1=$3; shift; _shifu_ack_arg ;;"
-  shifu_defer_help="${shifu_defer_help:-}\n    $4\n    Default: $2, set: $3"
-}
-
-_shifu_cmd_optb_build_comp_now() {
-  _shifu_opt_comp_eager_parse "$@"
-  shift $shifu_opt_count
-  _shifu_error_if_invalid_arg_order "$1" $shifu_parse_stage
-  shifu_case_stmt="$shifu_case_stmt)"
-}
-
-_shifu_cmd_optb_build_comp_defer() {
-  _shifu_opt_build_comp_defer_parse "$@"
-  shift $shifu_opt_count
-  shifu_defer_comp_case="${shifu_defer_comp_case:-}) shift ;;"
-}
-
-_shifu_cmd_optd_help() {
-  _shifu_opt_help_parse "$@"
-  shift $shifu_opt_count
-  _shifu_error_if_invalid_arg_order "$1" $shifu_help_stage
-  shifu_help_options="$shifu_help_options [$1]\n    $3\n    Default: $2"
-}
-
-_shifu_cmd_optd_build_now() {
-  shifu_eq_saved_args="$*"
-  _shifu_opt_case_parse "$@"
-  shift $shifu_opt_count
-  _shifu_error_if_invalid_arg_order "$1" $shifu_parse_stage
-  _shifu_set_variable "$1" "$2"
-  _shifu_update_case_stmt_option_value_check
-  shifu_case_stmt="$shifu_case_stmt $1=\$2; shift 2; _shifu_ack_arg 2 ;;"
-  _shifu_add_equals_case_arms shifu_case_stmt "$1"
-}
-
-_shifu_cmd_optd_build_defer() {
-  shifu_eq_saved_args="$*"
-  _shifu_opt_defer_parse "$@"
-  shift $shifu_opt_count
-  _shifu_set_variable "$1" "$2"
-  _shifu_update_case_stmt_option_value_check defer
-  shifu_defer_case="$shifu_defer_case $1=\\\$2; shift 2; _shifu_ack_arg 2 ;;"
-  shifu_defer_help="${shifu_defer_help:-} [$1]\n    $3\n    Default: $2"
-  _shifu_add_equals_defer_case_arms "$1"
-}
-
-_shifu_cmd_optv_build_comp_now() {
-  shifu_eq_saved_args="$*"
-  _shifu_opt_comp_eager_parse "$@"
-  shift $shifu_opt_count
-  _shifu_error_if_invalid_arg_order "$1" $shifu_parse_stage
-  shifu_case_stmt="$shifu_case_stmt) shift;"
-  _shifu_add_equals_comp_case_arms shifu_comp_eq_patterns
-}
-
-_shifu_cmd_optv_build_comp_defer() {
-  shifu_eq_saved_args="$*"
-  _shifu_opt_build_comp_defer_parse "$@"
-  shift $shifu_opt_count
-  shifu_defer_comp_case="${shifu_defer_comp_case:-}) shift;"
-  _shifu_add_equals_comp_case_arms shifu_comp_eq_patterns
-}
-
-_shifu_cmd_optr_help() {
-  _shifu_opt_help_parse "$@"
-  shift $shifu_opt_count
-  _shifu_error_if_invalid_arg_order "$1" $shifu_help_stage
-  shifu_help_options="$shifu_help_options $1\n    $2\n    Required"
-}
-
-_shifu_cmd_optr_build_now() {
-  shifu_eq_saved_args="$*"
-  _shifu_opt_case_parse "$@"
-  shift $shifu_opt_count
-  _shifu_error_if_invalid_arg_order "$1" $shifu_parse_stage
-  _shifu_list_append shifu_required_variables "$1"
-  _shifu_update_case_stmt_option_value_check
-  shifu_case_stmt="$shifu_case_stmt $1=\$2; shift 2; _shifu_ack_arg 2 ;;"
-  _shifu_add_equals_case_arms shifu_case_stmt "$1"
-}
-
-_shifu_cmd_optr_build_defer() {
-  shifu_eq_saved_args="$*"
-  _shifu_opt_defer_parse "$@"
-  shift $shifu_opt_count
-  _shifu_list_append shifu_required_variables "$1"
-  _shifu_update_case_stmt_option_value_check defer
-  shifu_defer_case="$shifu_defer_case $1=\\\$2; shift 2; _shifu_ack_arg 2 ;;"
-  shifu_defer_help="${shifu_defer_help:-} $1\n    $2\n    Required"
-  _shifu_add_equals_defer_case_arms "$1"
-}
-
-_shifu_cmd_optd_build_comp_now() { _shifu_cmd_optv_build_comp_now "$@"; }
-_shifu_cmd_optd_build_comp_defer() { _shifu_cmd_optv_build_comp_defer "$@"; }
-_shifu_cmd_optr_build_comp_now() { _shifu_cmd_optv_build_comp_now "$@"; }
-_shifu_cmd_optr_build_comp_defer() { _shifu_cmd_optv_build_comp_defer "$@"; }
-
-_shifu_cmd_argr_help() {
-  if [ $shifu_help_stage -lt 1 ]; then
-    shifu_help_stage=1
-  elif [ $shifu_help_stage -gt 1 ]; then
-    _shifu_error "No arguments after remaining are declared: $1"
-  fi
-  shifu_help_usage="${shifu_help_usage:-} [$1]"
-  shifu_help_arguments="${shifu_help_arguments:-}\n  $1\n    $2"
-}
-
-_shifu_cmd_argr_build_now() {
-  if [ $shifu_parse_stage -eq 0 ]; then
-    shifu_parse_stage=1
-    _shifu_update_case_stmt_invalid_option
-  elif [ $shifu_parse_stage -gt 1 ]; then
-    _shifu_error "No arguments after remaining are declared: $1"
-  fi
-  _shifu_set_variable "$1" ""
-  _shifu_list_append shifu_required_positionals "$1"
-  _shifu_append_on_new_line shifu_case_stmt "    $1=\\\$1; shift; _shifu_ack_arg"
-}
-
-_shifu_cmd_argr_build_comp_now() {
-  _shifu_opt_comp_preamble
-  if [ $shifu_parse_stage -eq 0 ]; then
-    shifu_parse_stage=1
-    _shifu_add_comp_eq_patterns
-    _shifu_append_on_new_line shifu_case_stmt "  *)"
-  elif [ $shifu_parse_stage -gt 1 ]; then
-    _shifu_error "No arguments after remaining are declared: $1"
-  fi
-}
-
-_shifu_cmd_args_help() {
-  shifu_help_stage=2
-  shifu_help_usage="$shifu_help_usage ...[REMAINING]"
-  shifu_help_arguments="$shifu_help_arguments\n  REMAINING\n    $1"
-}
-
-_shifu_cmd_args_build_now() {
-  [ $shifu_parse_stage -gt 1 ] && _shifu_error "Can only declare remaining arguments once: $1"
-  [ $shifu_parse_stage -eq 0 ] && _shifu_update_case_stmt_invalid_option
-  shifu_parse_stage=2
-}
-
-_shifu_cmd_args_build_comp_now() {
-  _shifu_opt_comp_preamble
-  [ $shifu_parse_stage -eq 2 ] && _shifu_error "Can only declare remaining arguments once: $1"
-  [ $shifu_parse_stage -eq 0 ] && _shifu_add_comp_eq_patterns
-  shifu_parse_stage=2
-}
-
-_shifu_cmd_opt_dispatch() {
-  shifu_dispatch_prefix="$1"; shift
-  if [ -n "${shifu_cmd_func:-}" ]; then
-    shifu_arg_scope=eager
-  elif [ "$1" = ":eager:" ]; then
-    shifu_arg_scope=eager; shift
-  elif [ "$1" = ":defer:" ]; then
-    shifu_arg_scope=defer; shift
-  else
-    _shifu_error "Mode :eager: or :defer: required in non-leaf commands"
-  fi
+_shifu_cmd_optb() {
   case ${shifu_mode:-0} in
-    $shifu_mode_help_run) "${shifu_dispatch_prefix}_help" "$@" ;;
+    $shifu_mode_help_run)
+      _shifu_opt_help_parse "$@"
+      shift $shifu_opt_count
+      _shifu_error_if_invalid_arg_order "$1" $shifu_help_stage
+      shifu_help_options="$shifu_help_options\n    $4\n    Default: ${2:-empty}, set: $3"
+      ;;
     $shifu_mode_args_run)
-      if [ "$shifu_arg_scope" = eager ]; then "${shifu_dispatch_prefix}_build_now" "$@"
-      else "${shifu_dispatch_prefix}_build_defer" "$@"; fi ;;
+      if [ "$shifu_arg_scope" = eager ]; then
+        _shifu_opt_case_parse "$@"
+        shift $shifu_opt_count
+        _shifu_error_if_invalid_arg_order "$1" $shifu_parse_stage
+        _shifu_set_variable "$1" "$2"
+        shifu_case_stmt="$shifu_case_stmt) $1=$3; shift; _shifu_ack_arg ;;"
+      else
+        _shifu_opt_defer_parse "$@"
+        shift $shifu_opt_count
+        _shifu_set_variable "$1" "$2"
+        shifu_defer_case="${shifu_defer_case:-}) $1=$3; shift; _shifu_ack_arg ;;"
+        shifu_defer_help="${shifu_defer_help:-}\n    $4\n    Default: $2, set: $3"
+      fi
+      ;;
     $shifu_mode_args_comp)
-      if [ "$shifu_arg_scope" = eager ]; then "${shifu_dispatch_prefix}_build_comp_now" "$@"
-      else "${shifu_dispatch_prefix}_build_comp_defer" "$@"; fi ;;
+      if [ "$shifu_arg_scope" = eager ]; then
+        _shifu_opt_comp_eager_parse "$@"
+        shift $shifu_opt_count
+        _shifu_error_if_invalid_arg_order "$1" $shifu_parse_stage
+        shifu_case_stmt="$shifu_case_stmt)"
+      else
+        _shifu_opt_build_comp_defer_parse "$@"
+        shift $shifu_opt_count
+        shifu_defer_comp_case="${shifu_defer_comp_case:-}) shift ;;"
+      fi
+      ;;
     $shifu_mode_opt_names_comp) _shifu_collect_option_names "$@" ;;
   esac
 }
 
-_shifu_cmd_arg_dispatch() {
-  shifu_dispatch_prefix="$1"; shift
-  [ -n "${shifu_cmd_func:-}" ] || _shifu_error "Positional arguments can only be used in leaf commands"
+_shifu_cmd_optd() {
   case ${shifu_mode:-0} in
-    $shifu_mode_help_run) "${shifu_dispatch_prefix}_help" "$@" ;;
-    $shifu_mode_args_run) "${shifu_dispatch_prefix}_build_now" "$@" ;;
-    $shifu_mode_args_comp) "${shifu_dispatch_prefix}_build_comp_now" "$@" ;;
+    $shifu_mode_help_run)
+      _shifu_opt_help_parse "$@"
+      shift $shifu_opt_count
+      _shifu_error_if_invalid_arg_order "$1" $shifu_help_stage
+      shifu_help_options="$shifu_help_options [$1]\n    $3\n    Default: $2"
+      ;;
+    $shifu_mode_args_run)
+      shifu_eq_saved_args="$*"
+      if [ "$shifu_arg_scope" = eager ]; then
+        _shifu_opt_case_parse "$@"
+        shift $shifu_opt_count
+        _shifu_error_if_invalid_arg_order "$1" $shifu_parse_stage
+        _shifu_set_variable "$1" "$2"
+        _shifu_update_case_stmt_option_value_check
+        shifu_case_stmt="$shifu_case_stmt $1=\$2; shift 2; _shifu_ack_arg 2 ;;"
+        _shifu_add_equals_case_arms shifu_case_stmt "$1"
+      else
+        _shifu_opt_defer_parse "$@"
+        shift $shifu_opt_count
+        _shifu_set_variable "$1" "$2"
+        _shifu_update_case_stmt_option_value_check defer
+        shifu_defer_case="$shifu_defer_case $1=\\\$2; shift 2; _shifu_ack_arg 2 ;;"
+        shifu_defer_help="${shifu_defer_help:-} [$1]\n    $3\n    Default: $2"
+        _shifu_add_equals_defer_case_arms "$1"
+      fi
+      ;;
+    $shifu_mode_args_comp)
+      shifu_eq_saved_args="$*"
+      if [ "$shifu_arg_scope" = eager ]; then
+        _shifu_opt_comp_eager_parse "$@"
+        shift $shifu_opt_count
+        _shifu_error_if_invalid_arg_order "$1" $shifu_parse_stage
+        shifu_case_stmt="$shifu_case_stmt) shift;"
+      else
+        _shifu_opt_build_comp_defer_parse "$@"
+        shift $shifu_opt_count
+        shifu_defer_comp_case="${shifu_defer_comp_case:-}) shift;"
+      fi
+      _shifu_add_equals_comp_case_arms shifu_comp_eq_patterns
+      ;;
+    $shifu_mode_opt_names_comp) _shifu_collect_option_names "$@" ;;
   esac
+}
+
+_shifu_cmd_optr() {
+  case ${shifu_mode:-0} in
+    $shifu_mode_help_run)
+      _shifu_opt_help_parse "$@"
+      shift $shifu_opt_count
+      _shifu_error_if_invalid_arg_order "$1" $shifu_help_stage
+      shifu_help_options="$shifu_help_options $1\n    $2\n    Required"
+      ;;
+    $shifu_mode_args_run)
+      shifu_eq_saved_args="$*"
+      if [ "$shifu_arg_scope" = eager ]; then
+        _shifu_opt_case_parse "$@"
+        shift $shifu_opt_count
+        _shifu_error_if_invalid_arg_order "$1" $shifu_parse_stage
+        _shifu_list_append shifu_required_variables "$1"
+        _shifu_update_case_stmt_option_value_check
+        shifu_case_stmt="$shifu_case_stmt $1=\$2; shift 2; _shifu_ack_arg 2 ;;"
+        _shifu_add_equals_case_arms shifu_case_stmt "$1"
+      else
+        _shifu_opt_defer_parse "$@"
+        shift $shifu_opt_count
+        _shifu_list_append shifu_required_variables "$1"
+        _shifu_update_case_stmt_option_value_check defer
+        shifu_defer_case="$shifu_defer_case $1=\\\$2; shift 2; _shifu_ack_arg 2 ;;"
+        shifu_defer_help="${shifu_defer_help:-} $1\n    $2\n    Required"
+        _shifu_add_equals_defer_case_arms "$1"
+      fi
+      ;;
+    $shifu_mode_args_comp)
+      shifu_eq_saved_args="$*"
+      if [ "$shifu_arg_scope" = eager ]; then
+        _shifu_opt_comp_eager_parse "$@"
+        shift $shifu_opt_count
+        _shifu_error_if_invalid_arg_order "$1" $shifu_parse_stage
+        shifu_case_stmt="$shifu_case_stmt) shift;"
+      else
+        _shifu_opt_build_comp_defer_parse "$@"
+        shift $shifu_opt_count
+        shifu_defer_comp_case="${shifu_defer_comp_case:-}) shift;"
+      fi
+      _shifu_add_equals_comp_case_arms shifu_comp_eq_patterns
+      ;;
+    $shifu_mode_opt_names_comp) _shifu_collect_option_names "$@" ;;
+  esac
+}
+
+_shifu_cmd_argr() {
+  case ${shifu_mode:-0} in
+    $shifu_mode_help_run)
+      if [ $shifu_help_stage -lt 1 ]; then
+        shifu_help_stage=1
+      elif [ $shifu_help_stage -gt 1 ]; then
+        _shifu_error "No arguments after remaining are declared: $1"
+      fi
+      shifu_help_usage="${shifu_help_usage:-} [$1]"
+      shifu_help_arguments="${shifu_help_arguments:-}\n  $1\n    $2"
+      ;;
+    $shifu_mode_args_run)
+      if [ $shifu_parse_stage -eq 0 ]; then
+        shifu_parse_stage=1
+        _shifu_update_case_stmt_invalid_option
+      elif [ $shifu_parse_stage -gt 1 ]; then
+        _shifu_error "No arguments after remaining are declared: $1"
+      fi
+      _shifu_set_variable "$1" ""
+      _shifu_list_append shifu_required_positionals "$1"
+      _shifu_append_on_new_line shifu_case_stmt "    $1=\\\$1; shift; _shifu_ack_arg"
+      ;;
+    $shifu_mode_args_comp)
+      _shifu_opt_comp_preamble
+      if [ $shifu_parse_stage -eq 0 ]; then
+        shifu_parse_stage=1
+        _shifu_add_comp_eq_patterns
+        _shifu_append_on_new_line shifu_case_stmt "  *)"
+      elif [ $shifu_parse_stage -gt 1 ]; then
+        _shifu_error "No arguments after remaining are declared: $1"
+      fi
+      ;;
+  esac
+}
+
+_shifu_cmd_args() {
+  case ${shifu_mode:-0} in
+    $shifu_mode_help_run)
+      shifu_help_stage=2
+      shifu_help_usage="$shifu_help_usage ...[REMAINING]"
+      shifu_help_arguments="$shifu_help_arguments\n  REMAINING\n    $1"
+      ;;
+    $shifu_mode_args_run)
+      [ $shifu_parse_stage -gt 1 ] && _shifu_error "Can only declare remaining arguments once: $1"
+      [ $shifu_parse_stage -eq 0 ] && _shifu_update_case_stmt_invalid_option
+      shifu_parse_stage=2
+      ;;
+    $shifu_mode_args_comp)
+      _shifu_opt_comp_preamble
+      [ $shifu_parse_stage -eq 2 ] && _shifu_error "Can only declare remaining arguments once: $1"
+      [ $shifu_parse_stage -eq 0 ] && _shifu_add_comp_eq_patterns
+      shifu_parse_stage=2
+      ;;
+  esac
+}
+
+_shifu_cmd_get_arg_scope() {
+  if [ -n "${shifu_cmd_func:-}" ]; then
+    shifu_arg_scope=eager
+    return 0
+  elif [ "$1" = ":eager:" ]; then
+    shifu_arg_scope=eager
+    return 1
+  elif [ "$1" = ":defer:" ]; then
+    shifu_arg_scope=defer
+    return 1
+  else
+    _shifu_error "Mode :eager: or :defer: required in non-leaf commands"
+  fi
+}
+
+_shifu_cmd_require_leaf() {
+  [ -n "${shifu_cmd_func:-}" ] || _shifu_error "Positional arguments can only be used in leaf commands"
 }
 
 _shifu_generate_tab_completion() {


### PR DESCRIPTION
I wound up not liking my attempt to dry out the cmd_{opt,arg} code as much as I could. It made it very difficult to find the parts of implementations I was looking for while reading the code, and while fewer sloc, was just not worth it. I think this is a decent compromise.