### PR TITLE
Parse options that appear after positionals

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,17 +632,6 @@ The option and argument declaration order in a command function matters:
 
 Shifu has a few variables that can be set after sourcing to change default behavior. Typically they are set just before calling `shifu_run`.
 
-#### `shifu_allow_options_anywhere`
-* Controls whether arguments starting with a dash are treated as errors
-* Type: bool
-  * `false`: options (arguments starting with `-`) are not allowed after positional arguments, shifu will error if it encounters one
-  * `true`: allows positional and remaining arguments that begin with a dash. Useful if flags need to be passed through cli arguments
-* Default: `false`
-* Example
-  ```sh
-  shifu_allow_options_anywhere=true
-  ```
-
 #### `shifu_complete_single_dash_options`
 * Controls tab completion behavior when current word is a single `-`
 * Type: bool

--- a/shifu
+++ b/shifu
@@ -274,8 +274,8 @@ _shifu_parse_args() {
   shifu_mode=$shifu_mode_args_run
   shifu_parse_stage=0
   _shifu_pos_idx=0
-  _shifu_pos_count=0
-  _shifu_remaining_declared=false
+  shifu_pos_count=0
+  shifu_remaining_declared=false
   _shifu_in_remaining=false
   shifu_parse_eager="$1"; shifu_cmd="$2"; shift 2
   [ "$shifu_parse_eager" = true ] && shifu_required_variables_eager=""
@@ -477,19 +477,39 @@ _shifu_opt_build_comp_defer_parse() {
 _shifu_comp_case_arm() {
   [ ${shifu_mode:-0} -ne $shifu_mode_args_comp ] && return
   [ "$shifu_arg_completion_set" = true ] && _shifu_error "Can only add one completion per argument"
-  if [ "$shifu_last_arg_is_eager" = true ]; then
+  if [ ${shifu_parse_stage:-0} -ge 2 ]; then
+    shifu_comp_remaining_fragment="$1"
+  elif [ ${shifu_parse_stage:-0} -eq 1 ]; then
+    eval "shifu_comp_pos_fragment_$((shifu_pos_count - 1))=\$1"
+  elif [ "$shifu_last_arg_is_eager" = true ]; then
     _shifu_append_on_new_line shifu_case_stmt '    [ \$# -ne 0 ] && shift'
-    shifu_case_stmt="$shifu_case_stmt || { $1; break; }"
-    if [ ${shifu_parse_stage:-0} -eq 0 ]; then
-      shifu_case_stmt="$shifu_case_stmt ;;"
-    else
-      shifu_case_stmt="$shifu_case_stmt;"
-    fi
+    shifu_case_stmt="$shifu_case_stmt || { $1; break; } ;;"
   else
     shifu_defer_comp_case="${shifu_defer_comp_case:-}
     [ \$# -ne 0 ] && shift || { $1; break; } ;;"
   fi
   shifu_arg_completion_set=true
+}
+
+_shifu_comp_positional_close() {
+  shifu_case_stmt="$shifu_case_stmt
+  *)
+    if [ \$# -eq 0 ]; then
+      case \$_shifu_pos_idx in"
+  shifu_comp_pos_i=0
+  while [ $shifu_comp_pos_i -lt $shifu_pos_count ]; do
+    eval "shifu_comp_pos_fragment=\${shifu_comp_pos_fragment_$shifu_comp_pos_i:-}"
+    shifu_case_stmt="$shifu_case_stmt
+        $shifu_comp_pos_i) $shifu_comp_pos_fragment ;;"
+    shifu_comp_pos_i=$((shifu_comp_pos_i + 1))
+  done
+  [ -n "${shifu_comp_remaining_fragment:-}" ] && shifu_case_stmt="$shifu_case_stmt
+        *) $shifu_comp_remaining_fragment ;;"
+  shifu_case_stmt="$shifu_case_stmt
+      esac
+      break
+    fi
+    _shifu_pos_idx=\$((_shifu_pos_idx + 1)); shift ;;"
 }
 
 _shifu_cmd_optb() {
@@ -633,10 +653,11 @@ _shifu_cmd_argr() {
       if [ $shifu_parse_stage -eq 0 ]; then
         shifu_parse_stage=1
         _shifu_add_comp_eq_patterns
-        _shifu_append_on_new_line shifu_case_stmt "  *)"
       elif [ $shifu_parse_stage -gt 1 ]; then
         _shifu_error "No arguments after remaining are declared: $1"
       fi
+      eval "shifu_comp_pos_fragment_$shifu_pos_count=''"
+      shifu_pos_count=$((shifu_pos_count + 1))
       ;;
   esac
 }
@@ -652,7 +673,7 @@ _shifu_cmd_args() {
       [ $shifu_parse_stage -gt 1 ] && _shifu_error "Can only declare remaining arguments once: $1"
       [ $shifu_parse_stage -eq 0 ] && _shifu_case_arm_invalid
       shifu_parse_stage=2
-      _shifu_remaining_declared=true
+      shifu_remaining_declared=true
       ;;
     $shifu_mode_args_comp)
       _shifu_opt_comp_preamble
@@ -812,6 +833,11 @@ _shifu_complete_subcmd_names() {
 _shifu_complete_func_args() {
   shifu_mode=$shifu_mode_args_comp
   shifu_parse_stage=0
+  _shifu_pos_idx=0
+  shifu_pos_count=0
+  shifu_remaining_declared=false
+  _shifu_in_remaining=false
+  shifu_comp_remaining_fragment=''
   shifu_parse_eager="$1"; shifu_cmd="$2"; shift 2
   _shifu_args_parsed=0
   shifu_comp_eq_patterns=""
@@ -833,7 +859,7 @@ ${shifu_defer_comp_case:-}"
   if [ "$shifu_parse_eager" = true ]; then
     _shifu_append_on_new_line shifu_case_stmt "  *) _shifu_comp_done=true ;;"
   elif [ $shifu_parse_stage -ne 0 ]; then
-    _shifu_append_on_new_line shifu_case_stmt "    _shifu_comp_done=true ;;"
+    _shifu_comp_positional_close
   elif [ $shifu_arg_completion_set = true ]; then
     _shifu_append_on_new_line shifu_case_stmt "  *) _shifu_comp_done=true ;;"
   else
@@ -903,9 +929,9 @@ _shifu_case_arm_invalid() {
 
 _shifu_case_close() {
   [ $shifu_parse_stage -eq 0 ] && _shifu_case_arm_invalid
-  if [ $_shifu_pos_count -gt 0 ]; then
+  if [ $shifu_pos_count -gt 0 ]; then
     _shifu_case_positional_close
-  elif [ "$_shifu_remaining_declared" = true ]; then
+  elif [ "$shifu_remaining_declared" = true ]; then
     _shifu_append_on_new_line shifu_case_stmt "    _shifu_in_remaining=true ;;"
   else
     _shifu_append_on_new_line shifu_case_stmt "    break;;"
@@ -954,12 +980,12 @@ _shifu_case_positional_open() {
 
 _shifu_case_arm_positional() {
   shifu_case_stmt="$shifu_case_stmt
-      $_shifu_pos_count) $1=\$1 ;;"
-  _shifu_pos_count=$((_shifu_pos_count + 1))
+      $shifu_pos_count) $1=\$1 ;;"
+  shifu_pos_count=$((shifu_pos_count + 1))
 }
 
 _shifu_case_positional_close() {
-  if [ "$_shifu_remaining_declared" = true ]; then
+  if [ "$shifu_remaining_declared" = true ]; then
     shifu_case_stmt="$shifu_case_stmt
       *) _shifu_in_remaining=true ;;"
   else

--- a/shifu
+++ b/shifu
@@ -274,6 +274,10 @@ _shifu_run() {
 _shifu_parse_args() {
   shifu_mode=$shifu_mode_args_run
   shifu_parse_stage=0
+  _shifu_pos_idx=0
+  _shifu_pos_count=0
+  _shifu_remaining_declared=false
+  _shifu_in_remaining=false
   shifu_parse_eager="$1"; shifu_cmd="$2"; shift 2
   [ "$shifu_parse_eager" = true ] && shifu_required_variables_eager=""
   shifu_required_positionals=""
@@ -285,6 +289,7 @@ _shifu_parse_args() {
   _shifu_args_parsed=0
   _shifu_n_args=$#
   while [ $# -ne 0 ]; do
+    [ "$_shifu_in_remaining" = true ] && break
     eval "$shifu_case_stmt" || _shifu_case_eval_error
     [ $# -eq $_shifu_n_args ] && _shifu_case_loop_error
     _shifu_n_args=$#
@@ -307,8 +312,6 @@ _shifu_parse_args() {
       _shifu_help \"$shifu_cmd\" 1
     fi"
   done
-  [ "$shifu_parse_eager" = true -o $# -eq 0 -o "$shifu_allow_options_anywhere" != false ] && return
-  _shifu_error_if_options "$@"
 }
 
 _shifu_ack_arg() {
@@ -618,6 +621,7 @@ _shifu_cmd_argr() {
       if [ $shifu_parse_stage -eq 0 ]; then
         shifu_parse_stage=1
         _shifu_case_arm_invalid
+        _shifu_case_positional_open
       elif [ $shifu_parse_stage -gt 1 ]; then
         _shifu_error "No arguments after remaining are declared: $1"
       fi
@@ -899,7 +903,11 @@ _shifu_case_arm_invalid() {
 
 _shifu_case_close() {
   [ $shifu_parse_stage -eq 0 ] && _shifu_case_arm_invalid
-  _shifu_append_on_new_line shifu_case_stmt "    break;;"
+  if [ $_shifu_pos_count -gt 0 ]; then
+    _shifu_case_positional_close
+  else
+    _shifu_append_on_new_line shifu_case_stmt "    break;;"
+  fi
   _shifu_append_on_new_line shifu_case_stmt "esac"
 }
 
@@ -937,8 +945,23 @@ _shifu_case_arm_append() {
   _shifu_case_write " _shifu_append_list ${1}_LIST \"$shifu_case_val\"; shift 2; _shifu_ack_arg 2 ;;"
 }
 
+_shifu_case_positional_open() {
+  shifu_case_stmt="$shifu_case_stmt
+    case \$_shifu_pos_idx in"
+}
+
 _shifu_case_arm_positional() {
-  _shifu_append_on_new_line shifu_case_stmt "    $1=\\\$1; shift; _shifu_ack_arg"
+  shifu_case_stmt="$shifu_case_stmt
+      $_shifu_pos_count) $1=\$1 ;;"
+  _shifu_pos_count=$((_shifu_pos_count + 1))
+}
+
+_shifu_case_positional_close() {
+  shifu_case_stmt="$shifu_case_stmt
+      *) echo \"Unexpected positional: \$1\"; _shifu_help \"\$shifu_cmd\" 1 ;;
+    esac
+    _shifu_pos_idx=\$((_shifu_pos_idx + 1))
+    shift; _shifu_ack_arg ;;"
 }
 
 _shifu_case_require_value() {

--- a/shifu
+++ b/shifu
@@ -79,7 +79,6 @@
 #   # ./intro --help    -> auto-generated help
 
 # config
-shifu_allow_options_anywhere=false
 shifu_complete_single_dash_options=false
 shifu_help_flags="-h --help"
 
@@ -289,8 +288,8 @@ _shifu_parse_args() {
   _shifu_args_parsed=0
   _shifu_n_args=$#
   while [ $# -ne 0 ]; do
-    [ "$_shifu_in_remaining" = true ] && break
     eval "$shifu_case_stmt" || _shifu_case_eval_error
+    [ "$_shifu_in_remaining" = true ] && break
     [ $# -eq $_shifu_n_args ] && _shifu_case_loop_error
     _shifu_n_args=$#
   done
@@ -969,7 +968,7 @@ _shifu_case_positional_close() {
   fi
   shifu_case_stmt="$shifu_case_stmt
     esac
-    [ \"\$_shifu_in_remaining\" = false ] && { _shifu_pos_idx=\$((_shifu_pos_idx + 1)); shift; _shifu_ack_arg; } ;;"
+    [ \"\$_shifu_in_remaining\" = true ] || { _shifu_pos_idx=\$((_shifu_pos_idx + 1)); shift; _shifu_ack_arg; } ;;"
 }
 
 _shifu_case_require_value() {
@@ -1034,15 +1033,6 @@ _shifu_var_set() {
 _shifu_append_on_new_line() {
   eval "$1=\"\$$1
 $2\""
-}
-
-_shifu_error_if_options() {
-  while [ $# -gt 0 ]; do
-    case "$1" in
-      -*) echo "No options allowed after any positional argument: $1"; return 1 ;;
-    esac
-    shift
-  done
 }
 
 _shifu_set_for_looping() {

--- a/shifu
+++ b/shifu
@@ -653,6 +653,7 @@ _shifu_cmd_args() {
       [ $shifu_parse_stage -gt 1 ] && _shifu_error "Can only declare remaining arguments once: $1"
       [ $shifu_parse_stage -eq 0 ] && _shifu_case_arm_invalid
       shifu_parse_stage=2
+      _shifu_remaining_declared=true
       ;;
     $shifu_mode_args_comp)
       _shifu_opt_comp_preamble
@@ -905,6 +906,8 @@ _shifu_case_close() {
   [ $shifu_parse_stage -eq 0 ] && _shifu_case_arm_invalid
   if [ $_shifu_pos_count -gt 0 ]; then
     _shifu_case_positional_close
+  elif [ "$_shifu_remaining_declared" = true ]; then
+    _shifu_append_on_new_line shifu_case_stmt "    _shifu_in_remaining=true ;;"
   else
     _shifu_append_on_new_line shifu_case_stmt "    break;;"
   fi
@@ -957,11 +960,16 @@ _shifu_case_arm_positional() {
 }
 
 _shifu_case_positional_close() {
+  if [ "$_shifu_remaining_declared" = true ]; then
+    shifu_case_stmt="$shifu_case_stmt
+      *) _shifu_in_remaining=true ;;"
+  else
+    shifu_case_stmt="$shifu_case_stmt
+      *) echo \"Unexpected positional: \$1\"; _shifu_help \"\$shifu_cmd\" 1 ;;"
+  fi
   shifu_case_stmt="$shifu_case_stmt
-      *) echo \"Unexpected positional: \$1\"; _shifu_help \"\$shifu_cmd\" 1 ;;
     esac
-    _shifu_pos_idx=\$((_shifu_pos_idx + 1))
-    shift; _shifu_ack_arg ;;"
+    [ \"\$_shifu_in_remaining\" = false ] && { _shifu_pos_idx=\$((_shifu_pos_idx + 1)); shift; _shifu_ack_arg; } ;;"
 }
 
 _shifu_case_require_value() {

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -771,7 +771,22 @@ test_shifu_complete() {
      "leaf-three leaf-four" \
   -- leaf_options_through_equals_arg \
      shifu_test_root_cmd "--f sub-two --eager-test=some_value leaf-four" \
-     "--fake-arg"
+     "--fake-arg" \
+  -- option_value_after_positional \
+     shifu_test_all_options_cmd "cur_word one -A" \
+     "flag option arg" \
+  -- second_positional_after_option \
+     shifu_test_all_options_cmd "cur_word one -f" \
+     "positional arg two" \
+  -- option_names_after_positional \
+     shifu_test_all_options_cmd "--flag one" \
+     "--flag-option-bin --flag-option-req --flag-option-def" \
+  -- remaining_after_positionals \
+     shifu_test_all_options_cmd "cur_word one two r1" \
+     "remaining args" \
+  -- defer_value_after_positional \
+     shifu_test_root_cmd "cur_word sub-two leaf-four fake -G" \
+     "defer_one defer_two defer_three"
 }
 
 test_shifu_complete_single_dash_with_config_shows_all_options() {

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -286,6 +286,15 @@ test_shifu_run_flags_anywhere() {
      "option=none one=one two=two repeated=[l_one][l_two] remaining=three four"
 }
 
+test_shifu_run_defer_option_after_positional() {
+  shifu_run shifu_test_root_cmd sub-two leaf-four fake -G defer_val -t test_val extra args
+  shifu_assert_zero exit_code $?
+  shifu_assert_strings_equal positional "$POSITIONAL_ARG" "fake"
+  shifu_assert_strings_equal defer_def "$DEFER_DEF" "defer_val"
+  shifu_assert_strings_equal test_arg "$TEST_ARG" "test_val"
+  shifu_assert_strings_equal remaining "$leaf_four_args" "extra args"
+}
+
 shifu_test_required_options_cmd() {
   shifu_cmd_name required-options
   shifu_cmd_subs shifu_test_leaf_three_cmd

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -232,6 +232,60 @@ test_shifu_run_required_args_unset() {
                    "Missing positional argument POSITIONAL_ARG_1"
 }
 
+shifu_test_flags_anywhere_cmd() {
+  shifu_cmd_name flags-anywhere
+  shifu_cmd_func shifu_test_flags_anywhere_func
+  shifu_cmd_optd --opt -- OPTION none "value option"
+  shifu_cmd_optd -l --list -- REPEATED... "" "repeatable option"
+  shifu_cmd_argr ARG_ONE "first positional"
+  shifu_cmd_argr ARG_TWO "second positional"
+  shifu_cmd_args "remaining arguments"
+}
+
+shifu_test_flags_anywhere_func() {
+  printf 'option=%s one=%s two=%s repeated=' "$OPTION" "$ARG_ONE" "$ARG_TWO"
+  while shifu_itr_list REPEATED; do
+      printf '[%s]' "$REPEATED";
+  done
+  printf ' remaining=%s' "$*"
+}
+
+test_shifu_run_flags_anywhere() {
+  run_test() {
+    shifu_test_params @args expected -- "$@"
+    actual=$(shifu_run shifu_test_flags_anywhere_cmd $args 2>&1)
+    shifu_assert_strings_equal output "$expected" "$actual"
+  }
+  shifu_parameterize_test run_test \
+  -- option_first \
+     "--opt val one two" \
+     "option=val one=one two=two repeated= remaining=" \
+  -- option_after_positionals \
+     "one two --opt val" \
+     "option=val one=one two=two repeated= remaining=" \
+  -- option_between_positionals \
+     "one --opt val two" \
+     "option=val one=one two=two repeated= remaining=" \
+  -- defaults \
+     "one two" \
+     "option=none one=one two=two repeated= remaining=" \
+  -- remaining \
+     "one two three four" \
+     "option=none one=one two=two repeated= remaining=three four" \
+  -- option_before_remaining \
+     "one two --opt val three four" \
+     "option=val one=one two=two repeated= remaining=three four" \
+  -- dash_data_in_remaining \
+     "one two three --opt val" \
+     "option=none one=one two=two repeated= remaining=three --opt val" \
+  -- repeatable_interspersed \
+     "-l l_one one -l l_two two" \
+     "option=none one=one two=two repeated=[l_one][l_two] remaining=" \
+  -- repeated_and_remaining \
+     "-l l_one one -l l_two two three four" \
+     "option=none one=one two=two repeated=[l_one][l_two] remaining=three four"
+}
+
 shifu_test_required_options_cmd() {
   shifu_cmd_name required-options
   shifu_cmd_subs shifu_test_leaf_three_cmd
@@ -435,70 +489,20 @@ Options
   shifu_assert_strings_equal error_message "$expected" "$actual"
 }
 
-test_shifu_run_bad_cmd_option_after_positional() {
-  expected="$(
-    echo 'No options allowed after any positional argument: -t'
-    printf 'Test leaf four cmd help
-
-Usage
-  leaf-four [OPTIONS] [POSITIONAL_ARG] ...[REMAINING]
-
-Arguments
-  POSITIONAL_ARG
-    positional argument help
-  REMAINING
-    remaining argument help
-
-Options
-  -f, --fake-arg [FAKE_ARG]
-    fake argument help
-    Default: fake_default
-  -t, --test-arg [TEST_ARG]
-    test argument help
-    Default: test_default
-  -h, --help
-    Show this help'
-  )"
-  actual=$(shifu_run shifu_test_leaf_four_cmd test -t fake)
-  shifu_assert_non_zero exit_code $?
-  shifu_assert_strings_equal error_message "$expected" "$actual"
+test_shifu_run_option_after_positional() {
+  shifu_run shifu_test_leaf_four_cmd test -t fake
+  shifu_assert_zero exit_code $?
+  shifu_assert_strings_equal positional "$POSITIONAL_ARG" "test"
+  shifu_assert_strings_equal test_arg "$TEST_ARG" "fake"
+  shifu_assert_empty remaining "$leaf_four_args"
 }
 
-test_shifu_run_bad_cmd_option_in_remaining() {
-  expected="$(
-    echo 'No options allowed after any positional argument: -t'
-    printf 'Test leaf four cmd help
-
-Usage
-  leaf-four [OPTIONS] [POSITIONAL_ARG] ...[REMAINING]
-
-Arguments
-  POSITIONAL_ARG
-    positional argument help
-  REMAINING
-    remaining argument help
-
-Options
-  -f, --fake-arg [FAKE_ARG]
-    fake argument help
-    Default: fake_default
-  -t, --test-arg [TEST_ARG]
-    test argument help
-    Default: test_default
-  -h, --help
-    Show this help'
-  )"
-  actual=$(shifu_run shifu_test_leaf_four_cmd fake -t test positional)
-  shifu_assert_non_zero exit_code $?
-  shifu_assert_strings_equal error_message "$expected" "$actual"
-}
-
-test_shifu_run_bad_cmd_option_w_allow_options_anywhere() {
-  shifu_allow_options_anywhere=true
+test_shifu_run_option_before_remaining() {
   shifu_run shifu_test_leaf_four_cmd fake -t test positional
   shifu_assert_zero exit_code $?
   shifu_assert_strings_equal positional "$POSITIONAL_ARG" "fake"
-  shifu_assert_strings_equal remaining "$leaf_four_args" "-t test positional"
+  shifu_assert_strings_equal test_arg "$TEST_ARG" "test"
+  shifu_assert_strings_equal remaining "$leaf_four_args" "positional"
 }
 
 test_shifu_run_args_invalid_option() {

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -786,7 +786,10 @@ test_shifu_complete() {
      "remaining args" \
   -- defer_value_after_positional \
      shifu_test_root_cmd "cur_word sub-two leaf-four fake -G" \
-     "defer_one defer_two defer_three"
+     "defer_one defer_two defer_three" \
+  -- option_interleaved_between_positionals \
+     shifu_test_all_options_cmd "cur_word one -A flag two" \
+     "remaining args"
 }
 
 test_shifu_complete_single_dash_with_config_shows_all_options() {

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -232,9 +232,9 @@ test_shifu_run_required_args_unset() {
                    "Missing positional argument POSITIONAL_ARG_1"
 }
 
-shifu_test_flags_anywhere_cmd() {
-  shifu_cmd_name flags-anywhere
-  shifu_cmd_func shifu_test_flags_anywhere_func
+shifu_test_options_after_positionals_cmd() {
+  shifu_cmd_name options-after-positionals
+  shifu_cmd_func shifu_test_options_after_positionals_func
   shifu_cmd_optd --opt -- OPTION none "value option"
   shifu_cmd_optd -l --list -- REPEATED... "" "repeatable option"
   shifu_cmd_argr ARG_ONE "first positional"
@@ -242,7 +242,7 @@ shifu_test_flags_anywhere_cmd() {
   shifu_cmd_args "remaining arguments"
 }
 
-shifu_test_flags_anywhere_func() {
+shifu_test_options_after_positionals_func() {
   printf 'option=%s one=%s two=%s repeated=' "$OPTION" "$ARG_ONE" "$ARG_TWO"
   while shifu_itr_list REPEATED; do
       printf '[%s]' "$REPEATED";
@@ -250,10 +250,10 @@ shifu_test_flags_anywhere_func() {
   printf ' remaining=%s' "$*"
 }
 
-test_shifu_run_flags_anywhere() {
+test_shifu_run_options_after_positionals() {
   run_test() {
     shifu_test_params @args expected -- "$@"
-    actual=$(shifu_run shifu_test_flags_anywhere_cmd $args 2>&1)
+    actual=$(shifu_run shifu_test_options_after_positionals_cmd $args 2>&1)
     shifu_assert_strings_equal output "$expected" "$actual"
   }
   shifu_parameterize_test run_test \


### PR DESCRIPTION
This PR aims to enable parsing of options that are passed after positional arguments are provided. Currently positional arguments are parsed by a `*)` in the parsing case statement and once that arm is entered, it cannot be left; therefore, no flags can be parsed after positional arguments have started getting parsed.

The strategy to enable this is to keep track of how many positional arguments have been parsed with a counter, and use an inner case statement on the current count to determine what variable a positional argument is assigned to inside the `*)` arm of the main parsing case statement.

This design is incompatible with the existing `shifu_allow_options_anywhere` configuration option since enabling it forced the shifu parser to treat trailing dash-prefixed arguments as data once positional argument parsing had begun and pass them through. Now the parser is aware of dash-prefixed arguments during positional argument parsing as they are treated as flags just like any other location. This PR, therefore, removes `shifu_allow_options_anywhere`. A new method of passing through dash-prefixed arguments will be developed in a future PR.