### PR TITLE
Support POSIX end of options delimiter: --

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,21 @@ The option and argument declaration order in a command function matters:
 1. Positional arguments are parsed in declaration order
 1. Options must be declared before any positional arguments, and positional arguments before remaining arguments
 
+#### End-of-options delimiter (`--`)
+
+A bare `--` stops option parsing; every argument after it is treated as a non-option argument, even if it begins with `-`. These fill any positional arguments, then overflow into `$@`. Use it to pass a value that starts with a dash, or to forward flags to another command. Note that this delimiter is what you type when running a shifu CLI; it is unrelated to the `--` separator in an option declaration (like the `shifu_cmd_optb` line below), which sits between the option's flags and its parsing configuration.
+
+```sh
+shifu_cmd_optb -v --verbose -- VERBOSE false true "Verbose output"
+shifu_cmd_args "Arguments forwarded to the wrapped command"
+```
+
+```txt
+cli --verbose        # VERBOSE = true,  $@ = <empty>
+cli -- --verbose     # VERBOSE = false, $@ = --verbose
+cli -- -x file.txt   # VERBOSE = false, $@ = -x file.txt
+```
+
 ### Completion functions
 
 #### `shifu_cmd_cpte`
@@ -670,7 +685,7 @@ Shifu has a few variables that can be set after sourcing to change default behav
 
 #### `shifu_add_cpts`
 * Registers one or more strings to add as completions
-* Must only be called within functions passed to `shifu_cmd_cptf`
+* [x] Must only be called within functions passed to `shifu_cmd_cptf`
 * Example
   ```sh
   dynamic_completions() {

--- a/README.md
+++ b/README.md
@@ -565,6 +565,8 @@ All option and argument functions accept a `variable` argument, the shell variab
 
 #### Notes
 
+##### Shared options in parent commands
+
 The signatures and examples above are for leaf commands (those using `shifu_cmd_func`). When you have options that are shared across subcommands, like a `--verbose` flag, you can declare them once in a parent command (those using `shifu_cmd_subs`) instead of repeating them in every subcommand.
 
 Option functions called in a parent command require a mode as the first argument. The mode changes when the option will be parsed, aka when it will be provided by the CLI user. The two available modes are:
@@ -583,6 +585,8 @@ Option functions called in a parent command require a mode as the first argument
   cli --config myconfig sub
   ```
 
+##### Positional and remaining argument declaration rules
+
 Positional and remaining argument functions (`shifu_cmd_argr`, `shifu_cmd_args`) can only be used in leaf commands.
 
 The option and argument declaration order in a command function matters:
@@ -591,7 +595,7 @@ The option and argument declaration order in a command function matters:
 1. Positional arguments are parsed in declaration order
 1. Options must be declared before any positional arguments, and positional arguments before remaining arguments
 
-#### End-of-options delimiter (`--`)
+##### End-of-options delimiter (`--`)
 
 A bare `--` stops option parsing; every argument after it is treated as a non-option argument, even if it begins with `-`. These fill any positional arguments, then overflow into `$@`. Use it to pass a value that starts with a dash, or to forward flags to another command. Note that this delimiter is what you type when running a shifu CLI; it is unrelated to the `--` separator in an option declaration (like the `shifu_cmd_optb` line below), which sits between the option's flags and its parsing configuration.
 

--- a/shifu
+++ b/shifu
@@ -277,6 +277,8 @@ _shifu_parse_args() {
   shifu_pos_count=0
   shifu_remaining_declared=false
   _shifu_in_remaining=false
+  _shifu_end_of_options=false
+  shifu_operand_stmt=""
   shifu_parse_eager="$1"; shifu_cmd="$2"; shift 2
   [ "$shifu_parse_eager" = true ] && shifu_required_variables_eager=""
   shifu_required_positionals=""
@@ -288,7 +290,11 @@ _shifu_parse_args() {
   _shifu_args_parsed=0
   _shifu_n_args=$#
   while [ $# -ne 0 ]; do
-    eval "$shifu_case_stmt" || _shifu_case_eval_error
+    if [ "$_shifu_end_of_options" = true ]; then
+      eval "$shifu_operand_stmt" || _shifu_case_eval_error
+    else
+      eval "$shifu_case_stmt" || _shifu_case_eval_error
+    fi
     [ "$_shifu_in_remaining" = true ] && break
     [ $# -eq $_shifu_n_args ] && _shifu_case_loop_error
     _shifu_n_args=$#
@@ -922,6 +928,8 @@ _shifu_case_arm_help() {
 }
 
 _shifu_case_arm_invalid() {
+  [ "${shifu_parse_eager:-true}" = false ] && shifu_case_stmt="$shifu_case_stmt
+  --) _shifu_end_of_options=true; shift; _shifu_ack_arg ;;"
   shifu_case_stmt="$shifu_case_stmt
   -*) echo \"Invalid option: \$1\"; _shifu_help \"\$shifu_cmd\" 1 ;;
   *)"
@@ -932,9 +940,12 @@ _shifu_case_close() {
   if [ $shifu_pos_count -gt 0 ]; then
     _shifu_case_positional_close
   elif [ "$shifu_remaining_declared" = true ]; then
-    _shifu_append_on_new_line shifu_case_stmt "    _shifu_in_remaining=true ;;"
+    shifu_case_stmt="$shifu_case_stmt
+    eval \"\$shifu_operand_stmt\" ;;"
+    shifu_operand_stmt="_shifu_in_remaining=true"
   else
     _shifu_append_on_new_line shifu_case_stmt "    break;;"
+    shifu_operand_stmt="echo \"Unexpected argument: \$1\"; _shifu_help \"\$shifu_cmd\" 1"
   fi
   _shifu_append_on_new_line shifu_case_stmt "esac"
 }
@@ -975,26 +986,27 @@ _shifu_case_arm_append() {
 
 _shifu_case_positional_open() {
   shifu_case_stmt="$shifu_case_stmt
-    case \$_shifu_pos_idx in"
+    eval \"\$shifu_operand_stmt\" ;;"
+  shifu_operand_stmt="case \$_shifu_pos_idx in"
 }
 
 _shifu_case_arm_positional() {
-  shifu_case_stmt="$shifu_case_stmt
-      $shifu_pos_count) $1=\$1 ;;"
+  shifu_operand_stmt="$shifu_operand_stmt
+  $shifu_pos_count) $1=\$1 ;;"
   shifu_pos_count=$((shifu_pos_count + 1))
 }
 
 _shifu_case_positional_close() {
   if [ "$shifu_remaining_declared" = true ]; then
-    shifu_case_stmt="$shifu_case_stmt
-      *) _shifu_in_remaining=true ;;"
+    shifu_operand_stmt="$shifu_operand_stmt
+  *) _shifu_in_remaining=true ;;"
   else
-    shifu_case_stmt="$shifu_case_stmt
-      *) echo \"Unexpected positional: \$1\"; _shifu_help \"\$shifu_cmd\" 1 ;;"
+    shifu_operand_stmt="$shifu_operand_stmt
+  *) echo \"Unexpected positional: \$1\"; _shifu_help \"\$shifu_cmd\" 1 ;;"
   fi
-  shifu_case_stmt="$shifu_case_stmt
-    esac
-    [ \"\$_shifu_in_remaining\" = true ] || { _shifu_pos_idx=\$((_shifu_pos_idx + 1)); shift; _shifu_ack_arg; } ;;"
+  shifu_operand_stmt="$shifu_operand_stmt
+esac
+[ \"\$_shifu_in_remaining\" = true ] || { _shifu_pos_idx=\$((_shifu_pos_idx + 1)); shift; _shifu_ack_arg; }"
 }
 
 _shifu_case_require_value() {

--- a/shifu
+++ b/shifu
@@ -278,7 +278,7 @@ _shifu_parse_args() {
   shifu_remaining_declared=false
   _shifu_in_remaining=false
   _shifu_end_of_options=false
-  shifu_operand_stmt=""
+  shifu_arg_stmt=""
   shifu_parse_eager="$1"; shifu_cmd="$2"; shift 2
   [ "$shifu_parse_eager" = true ] && shifu_required_variables_eager=""
   shifu_required_positionals=""
@@ -291,7 +291,7 @@ _shifu_parse_args() {
   _shifu_n_args=$#
   while [ $# -ne 0 ]; do
     if [ "$_shifu_end_of_options" = true ]; then
-      eval "$shifu_operand_stmt" || _shifu_case_eval_error
+      eval "$shifu_arg_stmt" || _shifu_case_eval_error
     else
       eval "$shifu_case_stmt" || _shifu_case_eval_error
     fi
@@ -499,23 +499,24 @@ _shifu_comp_case_arm() {
 
 _shifu_comp_positional_close() {
   shifu_case_stmt="$shifu_case_stmt
-  *)
-    if [ \$# -eq 0 ]; then
+  --) _shifu_end_of_options=true; shift ;;
+  *) eval \"\$shifu_comp_arg_stmt\" ;;"
+  shifu_comp_arg_stmt="if [ \$# -eq 0 ]; then
       case \$_shifu_pos_idx in"
   shifu_comp_pos_i=0
   while [ $shifu_comp_pos_i -lt $shifu_pos_count ]; do
     eval "shifu_comp_pos_fragment=\${shifu_comp_pos_fragment_$shifu_comp_pos_i:-}"
-    shifu_case_stmt="$shifu_case_stmt
+    shifu_comp_arg_stmt="$shifu_comp_arg_stmt
         $shifu_comp_pos_i) $shifu_comp_pos_fragment ;;"
     shifu_comp_pos_i=$((shifu_comp_pos_i + 1))
   done
-  [ -n "${shifu_comp_remaining_fragment:-}" ] && shifu_case_stmt="$shifu_case_stmt
+  [ -n "${shifu_comp_remaining_fragment:-}" ] && shifu_comp_arg_stmt="$shifu_comp_arg_stmt
         *) $shifu_comp_remaining_fragment ;;"
-  shifu_case_stmt="$shifu_case_stmt
+  shifu_comp_arg_stmt="$shifu_comp_arg_stmt
       esac
       break
     fi
-    _shifu_pos_idx=\$((_shifu_pos_idx + 1)); shift ;;"
+    _shifu_pos_idx=\$((_shifu_pos_idx + 1)); shift"
 }
 
 _shifu_cmd_optb() {
@@ -786,6 +787,11 @@ _shifu_complete() {
   done
   shifu_comp_option_names="${shifu_build_comp_defer_option_names:-}"
   _shifu_set_completing_option
+  if [ "$shifu_completing_option" = true -a -n "${shifu_cmd_func:-}" ]; then
+    for shifu_comp_sep_word in "$@"; do
+      [ "$shifu_comp_sep_word" = -- ] && { shifu_completing_option=false; break; }
+    done
+  fi
   [ "$shifu_completing_option" = true ] && shifu_completions=""
   if [ "$shifu_completing_option" = true -a -n "${shifu_cmd_func:-}" ]; then
     _shifu_complete_option_names
@@ -843,7 +849,9 @@ _shifu_complete_func_args() {
   shifu_pos_count=0
   shifu_remaining_declared=false
   _shifu_in_remaining=false
+  _shifu_end_of_options=false
   shifu_comp_remaining_fragment=''
+  shifu_comp_arg_stmt=''
   shifu_parse_eager="$1"; shifu_cmd="$2"; shift 2
   _shifu_args_parsed=0
   shifu_comp_eq_patterns=""
@@ -855,8 +863,14 @@ ${shifu_defer_comp_case:-}"
   shifu_arg_completion_set=true
   shifu_last_arg_is_eager=true
   "$shifu_cmd"
+  shifu_comp_past_separator=false
+  if [ "$shifu_parse_eager" = false ]; then
+    for shifu_comp_sep_word in "$@"; do
+      [ "$shifu_comp_sep_word" = -- ] && { shifu_comp_past_separator=true; break; }
+    done
+  fi
   case "${shifu_current_word:-}" in
-    -*) [ "$shifu_parse_eager" = false ] && return 0 ;;
+    -*) [ "$shifu_parse_eager" = false ] && [ "$shifu_comp_past_separator" = false ] && return 0 ;;
   esac
   if [ $shifu_parse_stage -eq 0 -a $shifu_arg_completion_set = false ]; then
     shifu_case_stmt="$shifu_case_stmt shift ;;"
@@ -876,7 +890,11 @@ ${shifu_defer_comp_case:-}"
   _shifu_n_args=$#
   _shifu_comp_done=false
   while [ "$_shifu_comp_done" = false ]; do
-    eval "$shifu_case_stmt" 2>/dev/null || return 1
+    if [ "$_shifu_end_of_options" = true ]; then
+      eval "$shifu_comp_arg_stmt" 2>/dev/null || return 1
+    else
+      eval "$shifu_case_stmt" 2>/dev/null || return 1
+    fi
     [ $# -eq $_shifu_n_args ] && _shifu_comp_done=true
     _shifu_n_args=$#
   done
@@ -941,11 +959,11 @@ _shifu_case_close() {
     _shifu_case_positional_close
   elif [ "$shifu_remaining_declared" = true ]; then
     shifu_case_stmt="$shifu_case_stmt
-    eval \"\$shifu_operand_stmt\" ;;"
-    shifu_operand_stmt="_shifu_in_remaining=true"
+    eval \"\$shifu_arg_stmt\" ;;"
+    shifu_arg_stmt="_shifu_in_remaining=true"
   else
     _shifu_append_on_new_line shifu_case_stmt "    break;;"
-    shifu_operand_stmt="echo \"Unexpected argument: \$1\"; _shifu_help \"\$shifu_cmd\" 1"
+    shifu_arg_stmt="echo \"Unexpected argument: \$1\"; _shifu_help \"\$shifu_cmd\" 1"
   fi
   _shifu_append_on_new_line shifu_case_stmt "esac"
 }
@@ -986,25 +1004,25 @@ _shifu_case_arm_append() {
 
 _shifu_case_positional_open() {
   shifu_case_stmt="$shifu_case_stmt
-    eval \"\$shifu_operand_stmt\" ;;"
-  shifu_operand_stmt="case \$_shifu_pos_idx in"
+    eval \"\$shifu_arg_stmt\" ;;"
+  shifu_arg_stmt="case \$_shifu_pos_idx in"
 }
 
 _shifu_case_arm_positional() {
-  shifu_operand_stmt="$shifu_operand_stmt
+  shifu_arg_stmt="$shifu_arg_stmt
   $shifu_pos_count) $1=\$1 ;;"
   shifu_pos_count=$((shifu_pos_count + 1))
 }
 
 _shifu_case_positional_close() {
   if [ "$shifu_remaining_declared" = true ]; then
-    shifu_operand_stmt="$shifu_operand_stmt
+    shifu_arg_stmt="$shifu_arg_stmt
   *) _shifu_in_remaining=true ;;"
   else
-    shifu_operand_stmt="$shifu_operand_stmt
+    shifu_arg_stmt="$shifu_arg_stmt
   *) echo \"Unexpected positional: \$1\"; _shifu_help \"\$shifu_cmd\" 1 ;;"
   fi
-  shifu_operand_stmt="$shifu_operand_stmt
+  shifu_arg_stmt="$shifu_arg_stmt
 esac
 [ \"\$_shifu_in_remaining\" = true ] || { _shifu_pos_idx=\$((_shifu_pos_idx + 1)); shift; _shifu_ack_arg; }"
 }

--- a/shifu
+++ b/shifu
@@ -788,8 +788,8 @@ _shifu_complete() {
   shifu_comp_option_names="${shifu_build_comp_defer_option_names:-}"
   _shifu_set_completing_option
   if [ "$shifu_completing_option" = true -a -n "${shifu_cmd_func:-}" ]; then
-    for shifu_comp_sep_word in "$@"; do
-      [ "$shifu_comp_sep_word" = -- ] && { shifu_completing_option=false; break; }
+    for shifu_comp_delim_word in "$@"; do
+      [ "$shifu_comp_delim_word" = -- ] && { shifu_completing_option=false; break; }
     done
   fi
   [ "$shifu_completing_option" = true ] && shifu_completions=""
@@ -863,14 +863,14 @@ ${shifu_defer_comp_case:-}"
   shifu_arg_completion_set=true
   shifu_last_arg_is_eager=true
   "$shifu_cmd"
-  shifu_comp_past_separator=false
+  shifu_comp_past_delimiter=false
   if [ "$shifu_parse_eager" = false ]; then
-    for shifu_comp_sep_word in "$@"; do
-      [ "$shifu_comp_sep_word" = -- ] && { shifu_comp_past_separator=true; break; }
+    for shifu_comp_delim_word in "$@"; do
+      [ "$shifu_comp_delim_word" = -- ] && { shifu_comp_past_delimiter=true; break; }
     done
   fi
   case "${shifu_current_word:-}" in
-    -*) [ "$shifu_parse_eager" = false ] && [ "$shifu_comp_past_separator" = false ] && return 0 ;;
+    -*) [ "$shifu_parse_eager" = false ] && [ "$shifu_comp_past_delimiter" = false ] && return 0 ;;
   esac
   if [ $shifu_parse_stage -eq 0 -a $shifu_arg_completion_set = false ]; then
     shifu_case_stmt="$shifu_case_stmt shift ;;"

--- a/tests/run
+++ b/tests/run
@@ -18,7 +18,7 @@ run_cmd() {
 
   cmd_optb -v --verbose -- verbose "" -v "Show status for each test, pass or fail"
   cmd_optb -x           -- set_x   "" -x "Set execution tracing for each test"
-  cmd_optd -t --timeout -- timeout 1     "Timeout in seconds for each shell test suite"
+  cmd_optd -t --timeout -- timeout 5     "Timeout in seconds for each shell test suite"
   cmd_optd -i --image   -- image   ""    "Docker image to run tests in"
   cmd_argr shell "Shell to run tests in. Options: all, ash, bash, dash, ksh, zsh"
   cmd_args "Specific tests to run"

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -72,15 +72,15 @@ shifu_test_leaf_func_one() {
 }
 
 shifu_test_leaf_func_two() {
-  leaf_two_args="$@"
+  leaf_two_args=$(shifu_test_format_args "$@")
 }
 
 shifu_test_leaf_three_func() {
-  leaf_three_args="$@"
+  leaf_three_args=$(shifu_test_format_args "$@")
 }
 
 shifu_test_leaf_func_four() {
-  leaf_four_args="$@"
+  leaf_four_args=$(shifu_test_format_args "$@")
 }
 
 shifu_test_all_options_cmd() {
@@ -153,7 +153,7 @@ test_shifu_run_good_cmd_defer_arg() {
   shifu_assert_zero exit_code $?
   shifu_assert_equal defer_bin "$DEFER_BIN" true
   shifu_assert_equal defer_def "$DEFER_DEF" defer_val
-  shifu_assert_equal leaf_three_args "$leaf_three_args" "one two"
+  shifu_assert_equal leaf_three_args "$leaf_three_args" "[one] [two]"
 }
 
 test_shifu_run_good_cmd_defer_and_eager_arg() {
@@ -162,7 +162,7 @@ test_shifu_run_good_cmd_defer_and_eager_arg() {
   shifu_assert_equal eager_test "$EAGER_TEST" "eager-val"
   shifu_assert_equal defer_bin "$DEFER_BIN" true
   shifu_assert_equal defer_def "$DEFER_DEF" defer_val
-  shifu_assert_equal leaf_three_args "$leaf_three_args" "one two"
+  shifu_assert_equal leaf_three_args "$leaf_three_args" "[one] [two]"
 }
 
 test_shifu_run_args_all_set() {
@@ -247,7 +247,7 @@ shifu_test_options_after_positionals_func() {
   while shifu_itr_list REPEATED; do
       printf '[%s]' "$REPEATED";
   done
-  printf ' remaining=%s' "$*"
+  printf ' remaining=%s' "$(shifu_test_format_args "$@")"
 }
 
 test_shifu_run_options_after_positionals() {
@@ -271,19 +271,19 @@ test_shifu_run_options_after_positionals() {
      "option=none one=one two=two repeated= remaining=" \
   -- remaining \
      "one two three four" \
-     "option=none one=one two=two repeated= remaining=three four" \
+     "option=none one=one two=two repeated= remaining=[three] [four]" \
   -- option_before_remaining \
      "one two --opt val three four" \
-     "option=val one=one two=two repeated= remaining=three four" \
+     "option=val one=one two=two repeated= remaining=[three] [four]" \
   -- dash_data_in_remaining \
      "one two three --opt val" \
-     "option=none one=one two=two repeated= remaining=three --opt val" \
+     "option=none one=one two=two repeated= remaining=[three] [--opt] [val]" \
   -- repeatable_interspersed \
      "-l l_one one -l l_two two" \
      "option=none one=one two=two repeated=[l_one][l_two] remaining=" \
   -- repeated_and_remaining \
      "-l l_one one -l l_two two three four" \
-     "option=none one=one two=two repeated=[l_one][l_two] remaining=three four"
+     "option=none one=one two=two repeated=[l_one][l_two] remaining=[three] [four]"
 }
 
 test_shifu_run_defer_option_after_positional() {
@@ -292,7 +292,66 @@ test_shifu_run_defer_option_after_positional() {
   shifu_assert_strings_equal positional "$POSITIONAL_ARG" "fake"
   shifu_assert_strings_equal defer_def "$DEFER_DEF" "defer_val"
   shifu_assert_strings_equal test_arg "$TEST_ARG" "test_val"
-  shifu_assert_strings_equal remaining "$leaf_four_args" "extra args"
+  shifu_assert_strings_equal remaining "$leaf_four_args" "[extra] [args]"
+}
+
+shifu_test_end_of_options_cmd() {
+  shifu_cmd_name end-of-options
+  shifu_cmd_func shifu_test_end_of_options_func
+  shifu_cmd_optd --opt -- OPTION none "value option"
+  shifu_cmd_argr ARG_ONE "first positional"
+  shifu_cmd_argr ARG_TWO "second positional"
+  shifu_cmd_args "remaining arguments"
+}
+
+shifu_test_end_of_options_func() {
+  printf 'option=%s one=%s two=%s remaining=%s' \
+    "$OPTION" "$ARG_ONE" "$ARG_TWO" "$(shifu_test_format_args "$@")"
+}
+
+test_shifu_run_end_of_options() {
+  run_test() {
+    shifu_test_params @args expected -- "$@"
+    actual=$(shifu_run shifu_test_end_of_options_cmd $args 2>&1)
+    shifu_assert_strings_equal output "$expected" "$actual"
+  }
+  shifu_parameterize_test run_test \
+  -- separator_noop \
+     "-- one two" \
+     "option=none one=one two=two remaining=" \
+  -- option_before_separator \
+     "--opt val -- one two" \
+     "option=val one=one two=two remaining=" \
+  -- dashes_fill_positionals \
+     "-- -one -two" \
+     "option=none one=-one two=-two remaining=" \
+  -- known_option_as_data \
+     "one -- --opt" \
+     "option=none one=one two=--opt remaining=" \
+  -- dash_data_to_remaining \
+     "one two -- -three -four" \
+     "option=none one=one two=two remaining=[-three] [-four]" \
+  -- second_separator_is_operand \
+     "one two -- --" \
+     "option=none one=one two=two remaining=[--]" \
+  -- separator_first_token \
+     "-- --opt val" \
+     "option=none one=--opt two=val remaining=" \
+  -- flags_anywhere_up_to_separator \
+     "one --opt val -- two" \
+     "option=val one=one two=two remaining="
+}
+
+shifu_test_end_of_options_no_args_cmd() {
+  shifu_cmd_name end-of-options-no-args
+  shifu_cmd_func no_op
+  shifu_cmd_optd --opt -- OPTION none "value option"
+}
+
+test_shifu_run_end_of_options_no_args_fails() {
+  actual=$(shifu_run shifu_test_end_of_options_no_args_cmd --opt val -- extra 2>&1)
+  shifu_assert_non_zero exit_code $?
+  shifu_assert_string_contains error_message "$actual" "Unexpected argument: extra"
 }
 
 shifu_test_required_options_cmd() {
@@ -511,7 +570,7 @@ test_shifu_run_option_before_remaining() {
   shifu_assert_zero exit_code $?
   shifu_assert_strings_equal positional "$POSITIONAL_ARG" "fake"
   shifu_assert_strings_equal test_arg "$TEST_ARG" "test"
-  shifu_assert_strings_equal remaining "$leaf_four_args" "positional"
+  shifu_assert_strings_equal remaining "$leaf_four_args" "[positional]"
 }
 
 test_shifu_run_args_invalid_option() {
@@ -1227,6 +1286,16 @@ shifu_test_params() {
     shift
     ua_idx=$((ua_idx + 1))
   done
+}
+
+shifu_test_format_args() {
+  # format "$@" as bracketed, space-separated tokens, e.g. [one] [two]; empty for none.
+  # reveals argument boundaries that "$*" / var="$@" would collapse into one string
+  fa_out=""
+  for fa_arg in "$@"; do
+    fa_out="${fa_out:+$fa_out }[$fa_arg]"
+  done
+  printf '%s' "$fa_out"
 }
 
 shifu_assert_empty() {

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -331,7 +331,7 @@ test_shifu_run_end_of_options() {
   -- dash_data_to_remaining \
      "one two -- -three -four" \
      "option=none one=one two=two remaining=[-three] [-four]" \
-  -- second_separator_is_operand \
+  -- second_separator_is_data \
      "one two -- --" \
      "option=none one=one two=two remaining=[--]" \
   -- separator_first_token \
@@ -848,6 +848,24 @@ test_shifu_complete() {
      "defer_one defer_two defer_three" \
   -- option_interleaved_between_positionals \
      shifu_test_all_options_cmd "cur_word one -A flag two" \
+     "remaining args" \
+  -- separator_not_counted_as_positional \
+     shifu_test_all_options_cmd "cur_word -- one" \
+     "positional arg two" \
+  -- no_option_names_after_separator \
+     shifu_test_all_options_cmd "cur_word one --" \
+     "positional arg two" \
+  -- dash_current_word_after_separator \
+     shifu_test_all_options_cmd "-A --" \
+     "positional arg one" \
+  -- known_option_as_data_after_separator \
+     shifu_test_all_options_cmd "cur_word one -- -two" \
+     "remaining args" \
+  -- remaining_after_data_positional \
+     shifu_test_all_options_cmd "cur_word one -- --two extra" \
+     "remaining args" \
+  -- remaining_source_after_separator \
+     shifu_test_all_options_cmd "cur_word one two --" \
      "remaining args"
 }
 

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -316,10 +316,10 @@ test_shifu_run_end_of_options() {
     shifu_assert_strings_equal output "$expected" "$actual"
   }
   shifu_parameterize_test run_test \
-  -- separator_noop \
+  -- delimiter_noop \
      "-- one two" \
      "option=none one=one two=two remaining=" \
-  -- option_before_separator \
+  -- option_before_delimiter \
      "--opt val -- one two" \
      "option=val one=one two=two remaining=" \
   -- dashes_fill_positionals \
@@ -331,13 +331,13 @@ test_shifu_run_end_of_options() {
   -- dash_data_to_remaining \
      "one two -- -three -four" \
      "option=none one=one two=two remaining=[-three] [-four]" \
-  -- second_separator_is_data \
+  -- second_delimiter_is_data \
      "one two -- --" \
      "option=none one=one two=two remaining=[--]" \
-  -- separator_first_token \
+  -- delimiter_first_token \
      "-- --opt val" \
      "option=none one=--opt two=val remaining=" \
-  -- flags_anywhere_up_to_separator \
+  -- flags_anywhere_up_to_delimiter \
      "one --opt val -- two" \
      "option=val one=one two=two remaining="
 }
@@ -849,22 +849,22 @@ test_shifu_complete() {
   -- option_interleaved_between_positionals \
      shifu_test_all_options_cmd "cur_word one -A flag two" \
      "remaining args" \
-  -- separator_not_counted_as_positional \
+  -- delimiter_not_counted_as_positional \
      shifu_test_all_options_cmd "cur_word -- one" \
      "positional arg two" \
-  -- no_option_names_after_separator \
+  -- no_option_names_after_delimiter \
      shifu_test_all_options_cmd "cur_word one --" \
      "positional arg two" \
-  -- dash_current_word_after_separator \
+  -- dash_current_word_after_delimiter \
      shifu_test_all_options_cmd "-A --" \
      "positional arg one" \
-  -- known_option_as_data_after_separator \
+  -- known_option_as_data_after_delimiter \
      shifu_test_all_options_cmd "cur_word one -- -two" \
      "remaining args" \
   -- remaining_after_data_positional \
      shifu_test_all_options_cmd "cur_word one -- --two extra" \
      "remaining args" \
-  -- remaining_source_after_separator \
+  -- remaining_source_after_delimiter \
      shifu_test_all_options_cmd "cur_word one two --" \
      "remaining args"
 }


### PR DESCRIPTION
This PR adds back the ability for users to specify dash-prefixed arguments after positional argument parsing has begun. This was previously made possible with the configuration option `shifu_allow_options_anywhere`, but the change in https://github.com/Ultramann/shifu/pull/48, which enabled options passed after positional arguments to be parsed, removed that configuration.

After doing some research on how to best support this I found that there's a POSIX guideline, [ref](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html#tag_12_02) `#10`:
> The first -- argument that is not an option-argument should be accepted as a delimiter indicating the end of options. Any following arguments should be treated as operands, even if they begin with the '-' character

This PR adds support this POSIX guideline.
