### PR TITLE
Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [keep a changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [semantic versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
@@ -10,15 +10,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Breaking
 
-* Removed the `shifu_allow_options_anywhere` configuration variable, made obsolete by parsing options after positional arguments. To pass an argument that starts with a dash, use the newly added end-of-options delimiter, `--`
+* Removed the `shifu_allow_options_anywhere` configuration variable. To pass an argument that starts with a dash, use the newly added end-of-options delimiter, `--` ([#49](https://github.com/Ultramann/shifu/pull/49))
 
 ### Added
 
-* Repeatable flags: suffix the variable name with `...` to make the flag repeatable, so each time it is used its argument is accrued instead of overwriting the previous value. A non-empty `<default>` becomes the first item in the list
-* `shifu_itr_list`: iterate over the arguments accrued by a repeatable flag in a `while` loop; the variable itself is not assigned the values
-* Equals as an option-value separator: long flags now accept `--flag=value` in addition to a space between the flag and its value
-* End-of-options delimiter (`--`): a bare `--` stops option parsing, and every argument after it is treated as a non-option argument, even if it begins with `-`. These fill any positional arguments, then overflow into `$@`. Use it to pass a value that starts with a dash, or to forward flags to another command. Tab completion is supported after `--`
-* Options may now appear after positional arguments, with tab completion support
+* Repeatable flags: suffix the variable name with `...` to make the flag repeatable, so each time it is used its argument is accrued instead of overwriting the previous value. A non-empty `<default>` becomes the first item in the list ([#45](https://github.com/Ultramann/shifu/pull/45))
+* `shifu_itr_list`: iterate over the arguments accrued by a repeatable flag in a `while` loop; the variable itself is not assigned the values ([#45](https://github.com/Ultramann/shifu/pull/45))
+* Equals as an option-value separator: long flags now accept `--flag=value` in addition to a space between the flag and its value ([#39](https://github.com/Ultramann/shifu/pull/39))
+* End-of-options delimiter (`--`): a bare `--` stops option parsing, and every argument after it is treated as a non-option argument, even if it begins with `-`. These fill any positional arguments, then overflow into `$@`. Use it to pass a value that starts with a dash, or to forward flags to another command. Tab completion is supported after `--` ([#49](https://github.com/Ultramann/shifu/pull/49))
+* Options may now appear after positional arguments, with tab completion support ([#48](https://github.com/Ultramann/shifu/pull/48))
 
 ## [0.1.0] - 2026-03-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,15 @@ The format is based on [keep a changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Breaking
 
-* Removed the `shifu_allow_options_anywhere` configuration variable. To pass an argument that starts with a dash, use the newly added end-of-options delimiter, `--` ([#49](https://github.com/Ultramann/shifu/pull/49))
+* Removed the `shifu_allow_options_anywhere` configuration variable. To pass an argument that starts with a dash, use the newly added end-of-options delimiter, `--` ([#49])
 
 ### Added
 
-* Repeatable flags: suffix the variable name with `...` to make the flag repeatable, so each time it is used its argument is accrued instead of overwriting the previous value. A non-empty `<default>` becomes the first item in the list ([#45](https://github.com/Ultramann/shifu/pull/45))
-* `shifu_itr_list`: iterate over the arguments accrued by a repeatable flag in a `while` loop; the variable itself is not assigned the values ([#45](https://github.com/Ultramann/shifu/pull/45))
-* Equals as an option-value separator: long flags now accept `--flag=value` in addition to a space between the flag and its value ([#39](https://github.com/Ultramann/shifu/pull/39))
-* End-of-options delimiter (`--`): a bare `--` stops option parsing, and every argument after it is treated as a non-option argument, even if it begins with `-`. These fill any positional arguments, then overflow into `$@`. Use it to pass a value that starts with a dash, or to forward flags to another command. Tab completion is supported after `--` ([#49](https://github.com/Ultramann/shifu/pull/49))
-* Options may now appear after positional arguments, with tab completion support ([#48](https://github.com/Ultramann/shifu/pull/48))
+* Repeatable flags: suffix the variable name with `...` to make the flag repeatable, so each time it is used its argument is accrued instead of overwriting the previous value. A non-empty `<default>` becomes the first item in the list ([#45])
+* `shifu_itr_list`: iterate over the arguments accrued by a repeatable flag in a `while` loop; the variable itself is not assigned the values ([#45])
+* Equals as an option-value separator: long flags now accept `--flag=value` in addition to a space between the flag and its value ([#39])
+* End-of-options delimiter (`--`): a bare `--` stops option parsing, and every argument after it is treated as a non-option argument, even if it begins with `-`. These fill any positional arguments, then overflow into `$@`. Use it to pass a value that starts with a dash, or to forward flags to another command. Tab completion is supported after `--` ([#49])
+* Options may now appear after positional arguments, with tab completion support ([#48])
 
 ## [0.1.0] - 2026-03-29
 
@@ -37,3 +37,8 @@ The format is based on [keep a changelog](https://keepachangelog.com/en/1.1.0/),
 [Unreleased]: https://github.com/Ultramann/shifu/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/Ultramann/shifu/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Ultramann/shifu/releases/tag/v0.1.0
+
+[#49]: https://github.com/Ultramann/shifu/pull/49
+[#48]: https://github.com/Ultramann/shifu/pull/48
+[#45]: https://github.com/Ultramann/shifu/pull/45
+[#39]: https://github.com/Ultramann/shifu/pull/39

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [keep a changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-## [0.2.0] - 2026-07-11
+## [0.2.0] - 2026-07-12
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0] - 2026-07-11
+
+### Breaking
+
+* Removed the `shifu_allow_options_anywhere` configuration variable, made obsolete by parsing options after positional arguments. To pass an argument that starts with a dash, use the newly added end-of-options delimiter, `--`
+
+### Added
+
+* Repeatable flags: suffix the variable name with `...` to make the flag repeatable, so each time it is used its argument is accrued instead of overwriting the previous value. A non-empty `<default>` becomes the first item in the list
+* `shifu_itr_list`: iterate over the arguments accrued by a repeatable flag in a `while` loop; the variable itself is not assigned the values
+* Equals as an option-value separator: long flags now accept `--flag=value` in addition to a space between the flag and its value
+* End-of-options delimiter (`--`): a bare `--` stops option parsing, and every argument after it is treated as a non-option argument, even if it begins with `-`. These fill any positional arguments, then overflow into `$@`. Use it to pass a value that starts with a dash, or to forward flags to another command. Tab completion is supported after `--`
+* Options may now appear after positional arguments, with tab completion support
+
+## [0.1.0] - 2026-03-29
+
+### Added
+
+* Initial release: a declarative framework that makes creating powerful CLIs from shell scripts simple, all in a single POSIX shell file with no dependencies
+* Commands as the core building block: a DSL of `cmd` functions that shifu uses to build a CLI, run or referenced as subcommands via `shifu_run`
+* Command info is specified with functions: `shifu_cmd_name`, `shifu_cmd_subs`, `shifu_cmd_func`, `shifu_cmd_help`, and `shifu_cmd_long`
+* Argument parsing: options `shifu_cmd_optb` (binary), `shifu_cmd_optd` (with default), and `shifu_cmd_optr` (required), plus positional and remaining arguments `shifu_cmd_argr` and `shifu_cmd_args`. Options declared in a parent command can be scoped across its subcommands via `:eager:` and `:defer:` modes
+* Help string formatting: auto-generated, (sub)command scoped help
+* Tab completion for interactive shells, including enumerated values (`shifu_cmd_cpte`), custom completion functions (`shifu_cmd_cptf` with `shifu_add_cpts`), and path completion (`shifu_cmd_cptp`)
+* Configuration variables: `shifu_allow_options_anywhere`, `shifu_complete_single_dash_options`, and `shifu_help_flags`
+* `shifu_less`: expose the `cmd` functions without the `shifu_` prefix
+* Compatibility with POSIX-based shells; tested with ash, bash, dash, ksh, and zsh
+
+[Unreleased]: https://github.com/Ultramann/shifu/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/Ultramann/shifu/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/Ultramann/shifu/releases/tag/v0.1.0


### PR DESCRIPTION
This PR adds a changelog based on [keep a changelog](https://keepachangelog.com/en/1.1.0/), and prepares the 0.2.0 release. 

I'd been on the fence about keeping a changelog for this project since it is still pre-1.0; but the more I thought about it, the more I realized it was worth doing because I think I have a number of breaking changes I want to work on soon and it's a much better user experience to have documentation about those updates.