### PR TITLE
Add support for parsing bundled short options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [keep a changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-* Bundled short options: a single dash followed by multiple, a bundle of, short options is expanded, so `-abc` is equivalent to `-a -b -c`. A required or option with default may end a bundle and will consume the next argument (`-abo file`). Exact multi-character single-dash flags such as `-readonly` still take precedence, and a help flag shows help from any position in a bundle ([#53])
+* Bundled short options: a single dash followed by a bundle of short options is expanded, so `-abc` is equivalent to `-a -b -c`. A required or defaulted option may end a bundle and will consume the next argument (`-abo file`). Exact multi-character single-dash flags such as `-readonly` still take precedence, and a help flag in any bundle position will short-circuit to showing the help ([#53])
 
 ## [0.2.0] - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [keep a changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+* Bundled short options: a single dash followed by multiple, a bundle of, short options is expanded, so `-abc` is equivalent to `-a -b -c`. A required or option with default may end a bundle and will consume the next argument (`-abo file`). Exact multi-character single-dash flags such as `-readonly` still take precedence, and a help flag shows help from any position in a bundle ([#53])
+
 ## [0.2.0] - 2026-07-12
 
 ### Breaking
@@ -38,6 +42,7 @@ The format is based on [keep a changelog](https://keepachangelog.com/en/1.1.0/),
 [0.2.0]: https://github.com/Ultramann/shifu/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Ultramann/shifu/releases/tag/v0.1.0
 
+[#53]: https://github.com/Ultramann/shifu/pull/53
 [#49]: https://github.com/Ultramann/shifu/pull/49
 [#48]: https://github.com/Ultramann/shifu/pull/48
 [#45]: https://github.com/Ultramann/shifu/pull/45

--- a/README.md
+++ b/README.md
@@ -610,6 +610,25 @@ cli -- --verbose     # VERBOSE = false, $@ = --verbose
 cli -- -x file.txt   # VERBOSE = false, $@ = -x file.txt
 ```
 
+##### Bundling short options
+
+Short options, those with a single dash and one character, can be passed together, in a bundle, behind one dash:
+* A required/default option may end a bundle and the following argument will be parsed as the last option's value
+* An option declared with more than one character after its dash is matched exactly and takes precedence over bundling, so a flag declared as `-readonly` is always read whole, never as `-r -e ...`
+* A help flag triggers help from any position in a bundle, so both `-vh` and `-hv` print help and exit
+  * This also works if a different help flag is specified with [`shifu_help_flags`](#shifu_help_flags)
+
+```sh
+shifu_cmd_optb -a --all    -- ALL false true  "Process all"
+shifu_cmd_optb -l --long   -- LONG false true "Long output"
+shifu_cmd_optd -o --output -- OUTPUT none     "Output file"
+```
+
+```txt
+cli -al             # ALL = true, LONG = true, OUTPUT = none
+cli -alo out.txt    # ALL = true, LONG = true, OUTPUT = out.txt
+```
+
 ### Completion functions
 
 #### `shifu_cmd_cpte`

--- a/README.md
+++ b/README.md
@@ -689,7 +689,7 @@ Shifu has a few variables that can be set after sourcing to change default behav
 
 #### `shifu_add_cpts`
 * Registers one or more strings to add as completions
-* [x] Must only be called within functions passed to `shifu_cmd_cptf`
+* Must only be called within functions passed to `shifu_cmd_cptf`
 * Example
   ```sh
   dynamic_completions() {

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Arguments and help strings are scoped to each subcommand. Parent commands can al
 
 Below is a demo of [`examples/dispatch`](/examples/dispatch), a CLI with two subcommands, `hello` and `echo`, each with their own arguments. Annotated source code of the CLI can be found in the expandable section below the demo.
 
-![Quickstart](/assets/dispatch_demo.gif)
+![Dispatch](/assets/dispatch_demo.gif)
 
 <details>
 

--- a/shifu
+++ b/shifu
@@ -98,16 +98,6 @@ _shifu_setup() {
   _shifu_help_short_chars
 }
 
-_shifu_help_short_chars() {
-  shifu_help_short=""
-  _shifu_set_for_looping shifu_help_flags_list shifu_help_flags
-  for shifu_help_flag in $shifu_help_flags_list; do
-    case "$shifu_help_flag" in
-      -?) _shifu_append_short shifu_help_short "${shifu_help_flag#-}" ;;
-    esac
-  done
-}
-
 # api
 shifu_run() {
   _shifu_setup
@@ -196,24 +186,6 @@ shifu_list_delim='#=|=#'
 
 _shifu_append_list() {
   eval "$1=\"\${$1:-}\$2\$shifu_list_delim\""
-}
-
-_shifu_append_short() {
-  eval "$1=\"\${$1:+\$$1|}\$2\""
-}
-
-_shifu_collect_short_flags() {
-  shifu_csf_kind="$1"; shift
-  while [ $# -gt 0 ] && [ "$1" != -- ]; do
-    case "$1" in
-      -?) if [ "$shifu_arg_scope" = defer ]; then
-            _shifu_append_short "shifu_defer_short_$shifu_csf_kind" "${1#-}"
-          else
-            _shifu_append_short "shifu_short_$shifu_csf_kind" "${1#-}"
-          fi ;;
-    esac
-    shift
-  done
 }
 
 shifu_itr_list() {
@@ -469,6 +441,16 @@ _shifu_help_display_flags() {
   done
 }
 
+_shifu_help_short_chars() {
+  shifu_help_short=""
+  _shifu_set_for_looping shifu_help_flags_list shifu_help_flags
+  for shifu_help_flag in $shifu_help_flags_list; do
+    case "$shifu_help_flag" in
+      -?) _shifu_append_short shifu_help_short "${shifu_help_flag#-}" ;;
+    esac
+  done
+}
+
 _shifu_opt_help_parse() {
   _shifu_opt_build shifu_help_options '\n  ' ', ' "$@"
 }
@@ -563,7 +545,7 @@ _shifu_cmd_optb() {
       ;;
     $shifu_mode_args_run)
       _shifu_case_arm_begin "$shifu_arg_scope" "$@"
-      _shifu_collect_short_flags bin "$@"
+      _shifu_collect_short_flags "$@"
       shift $shifu_opt_count
       _shifu_guard_arg_order "$1"
       _shifu_var_default "$1" "$2"
@@ -572,7 +554,7 @@ _shifu_cmd_optb() {
         shifu_defer_help="${shifu_defer_help:-}\n    $4\n    Default: $2, set: $3"
       ;;
     $shifu_mode_args_comp)
-      _shifu_collect_short_flags bin "$@"
+      _shifu_collect_short_flags "$@"
       if [ "$shifu_arg_scope" = eager ]; then
         _shifu_opt_comp_eager_parse "$@"
         shift $shifu_opt_count
@@ -951,6 +933,23 @@ _shifu_filter_matching_options() {
       "$shifu_filter_current_word"*)
         _shifu_list_append shifu_completions "$shifu_filter_option" ;;
     esac
+  done
+}
+
+_shifu_append_short() {
+  eval "$1=\"\${$1:+\$$1|}\$2\""
+}
+
+_shifu_collect_short_flags() {
+  while [ $# -gt 0 ] && [ "$1" != -- ]; do
+    case "$1" in
+      -?) if [ "$shifu_arg_scope" = defer ]; then
+            _shifu_append_short shifu_defer_short_bin "${1#-}"
+          else
+            _shifu_append_short shifu_short_bin "${1#-}"
+          fi ;;
+    esac
+    shift
   done
 }
 

--- a/shifu
+++ b/shifu
@@ -95,6 +95,17 @@ _shifu_setup() {
   _shifu_validate_help_flags
   _shifu_help_case_pattern
   _shifu_help_display_flags
+  _shifu_help_short_chars
+}
+
+_shifu_help_short_chars() {
+  shifu_help_short=""
+  _shifu_set_for_looping shifu_help_flags_list shifu_help_flags
+  for shifu_help_flag in $shifu_help_flags_list; do
+    case "$shifu_help_flag" in
+      -?) _shifu_append_short shifu_help_short "${shifu_help_flag#-}" ;;
+    esac
+  done
 }
 
 # api
@@ -187,6 +198,24 @@ _shifu_append_list() {
   eval "$1=\"\${$1:-}\$2\$shifu_list_delim\""
 }
 
+_shifu_append_short() {
+  eval "$1=\"\${$1:+\$$1|}\$2\""
+}
+
+_shifu_collect_short_flags() {
+  shifu_csf_kind="$1"; shift
+  while [ $# -gt 0 ] && [ "$1" != -- ]; do
+    case "$1" in
+      -?) if [ "$shifu_arg_scope" = defer ]; then
+            _shifu_append_short "shifu_defer_short_$shifu_csf_kind" "${1#-}"
+          else
+            _shifu_append_short "shifu_short_$shifu_csf_kind" "${1#-}"
+          fi ;;
+    esac
+    shift
+  done
+}
+
 shifu_itr_list() {
   if ! [ "${shifu_itr_temp+set}" ]; then
     eval "shifu_itr_temp=\$$1_LIST"
@@ -243,6 +272,7 @@ _shifu_run() {
   _shifu_load_cur_cmd "$1"
   shifu_cmd="$1"; shift
   shifu_required_variables=""
+  shifu_defer_short_bin=""
   while [ $# -ne 0 -a -n "${shifu_cmd_subs:-}" ]; do
     _shifu_parse_args true "$shifu_cur_cmd" "$@"
     shifu_mode=$shifu_mode_cmds_run
@@ -279,11 +309,15 @@ _shifu_parse_args() {
   _shifu_in_remaining=false
   _shifu_end_of_options=false
   shifu_arg_stmt=""
+  shifu_short_bin=""
   shifu_parse_eager="$1"; shifu_cmd="$2"; shift 2
   [ "$shifu_parse_eager" = true ] && shifu_required_variables_eager=""
   shifu_required_positionals=""
   _shifu_case_open
   _shifu_case_inline_deferred
+  if [ "$shifu_parse_eager" = false ]; then
+    [ -n "${shifu_defer_short_bin:-}" ] && shifu_short_bin="${shifu_short_bin:+$shifu_short_bin|}$shifu_defer_short_bin"
+  fi
   _shifu_case_arm_help
   "$shifu_cmd"
   _shifu_case_close
@@ -529,6 +563,7 @@ _shifu_cmd_optb() {
       ;;
     $shifu_mode_args_run)
       _shifu_case_arm_begin "$shifu_arg_scope" "$@"
+      _shifu_collect_short_flags bin "$@"
       shift $shifu_opt_count
       _shifu_guard_arg_order "$1"
       _shifu_var_default "$1" "$2"
@@ -945,9 +980,32 @@ _shifu_case_arm_help() {
   _shifu_append_on_new_line shifu_case_stmt "  $shifu_help_pattern) _shifu_help \"$shifu_cmd\" 0 ;; "
 }
 
+_shifu_case_arm_bundle() {
+  shifu_bundle_bin="$shifu_short_bin"
+  [ -n "${shifu_help_short:-}" ] && shifu_bundle_bin="${shifu_bundle_bin:+$shifu_bundle_bin|}$shifu_help_short"
+  [ -n "$shifu_bundle_bin" ] || return 0
+  if [ $shifu_mode -eq $shifu_mode_args_comp ]; then
+    shifu_bundle_ack=""
+    shifu_bundle_default="_shifu_comp_done=true"
+  else
+    shifu_bundle_ack="; _shifu_args_parsed=\$((_shifu_args_parsed - 1))"
+    shifu_bundle_default="echo \"Invalid option: \$1\"; _shifu_help \"\$shifu_cmd\" 1"
+  fi
+  shifu_case_stmt="$shifu_case_stmt
+  -[!-]?*)
+    _shifu_body=\"\${1#-}\"; _shifu_tail=\"\${_shifu_body#?}\"; _shifu_head=\"\${_shifu_body%\"\$_shifu_tail\"}\"
+    case \"\$_shifu_head\" in"
+  [ -n "$shifu_bundle_bin" ] && shifu_case_stmt="$shifu_case_stmt
+    $shifu_bundle_bin) shift; set -- \"-\$_shifu_head\" \"-\$_shifu_tail\" \"\$@\"$shifu_bundle_ack ;;"
+  shifu_case_stmt="$shifu_case_stmt
+    *) $shifu_bundle_default ;;
+  esac ;;"
+}
+
 _shifu_case_arm_invalid() {
   [ "${shifu_parse_eager:-true}" = false ] && shifu_case_stmt="$shifu_case_stmt
   --) _shifu_end_of_options=true; shift; _shifu_ack_arg ;;"
+  _shifu_case_arm_bundle
   shifu_case_stmt="$shifu_case_stmt
   -*) echo \"Invalid option: \$1\"; _shifu_help \"\$shifu_cmd\" 1 ;;
   *)"

--- a/shifu
+++ b/shifu
@@ -572,6 +572,7 @@ _shifu_cmd_optb() {
         shifu_defer_help="${shifu_defer_help:-}\n    $4\n    Default: $2, set: $3"
       ;;
     $shifu_mode_args_comp)
+      _shifu_collect_short_flags bin "$@"
       if [ "$shifu_arg_scope" = eager ]; then
         _shifu_opt_comp_eager_parse "$@"
         shift $shifu_opt_count
@@ -887,6 +888,7 @@ _shifu_complete_func_args() {
   _shifu_end_of_options=false
   shifu_comp_remaining_fragment=''
   shifu_comp_arg_stmt=''
+  shifu_short_bin=""
   shifu_parse_eager="$1"; shifu_cmd="$2"; shift 2
   _shifu_args_parsed=0
   shifu_comp_eq_patterns=""
@@ -897,6 +899,9 @@ ${shifu_defer_comp_case:-}"
   fi
   shifu_arg_completion_set=true
   shifu_last_arg_is_eager=true
+  if [ "$shifu_parse_eager" = false ]; then
+    [ -n "${shifu_defer_short_bin:-}" ] && shifu_short_bin="${shifu_short_bin:+$shifu_short_bin|}$shifu_defer_short_bin"
+  fi
   "$shifu_cmd"
   shifu_comp_past_delimiter=false
   if [ "$shifu_parse_eager" = false ]; then
@@ -911,6 +916,7 @@ ${shifu_defer_comp_case:-}"
     shifu_case_stmt="$shifu_case_stmt shift ;;"
   fi
   _shifu_add_comp_eq_patterns
+  _shifu_case_arm_bundle
   if [ "$shifu_parse_eager" = true ]; then
     _shifu_append_on_new_line shifu_case_stmt "  *) _shifu_comp_done=true ;;"
   elif [ $shifu_parse_stage -ne 0 ]; then

--- a/shifu
+++ b/shifu
@@ -953,7 +953,8 @@ _shifu_filter_matching_options() {
 #   _shifu_case_open                      start a fresh statement (subject read from mode)
 #   _shifu_case_inline_deferred           inline accumulated deferred arms into a leaf statement
 #   _shifu_case_arm_help                  emit the help-flag arm
-#   _shifu_case_arm_invalid               emit the invalid-option arm, open the positional branch
+#   _shifu_case_arm_bundle                emit the -XYZ bundle arm, just before -*) so exact arms win
+#   _shifu_case_arm_invalid               emit the bundle arm + invalid-option arm, open the positional branch
 #   _shifu_case_close                     finish the statement (default arm + esac)
 #   _shifu_case_arm_begin <scope> ..      open an option arm: select eager/defer buffer +
 #                                         escaping ($shifu_case_val), emit the flag pattern

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -866,7 +866,19 @@ test_shifu_complete() {
      "remaining args" \
   -- remaining_source_after_delimiter \
      shifu_test_all_options_cmd "cur_word one two --" \
-     "remaining args"
+     "remaining args" \
+  -- positional_after_bundle \
+     shifu_test_bundle_cmd "cur_word -ab" \
+     "one two three" \
+  -- positional_after_long_bundle \
+     shifu_test_bundle_cmd "cur_word -abc" \
+     "one two three" \
+  -- positional_after_exact_multi \
+     shifu_test_bundle_cmd "cur_word -readonly" \
+     "one two three" \
+  -- subcmds_after_eager_bundle \
+     shifu_test_eager_root_cmd "cur_word sub-multi-eager -bc" \
+     "leaf-three leaf-four"
 }
 
 test_shifu_complete_single_dash_with_config_shows_all_options() {
@@ -1290,18 +1302,18 @@ test_shifu_run_bundle_errors() {
 test_shifu_run_eager_bundle() {
   run_test() {
     shifu_test_params @args expected -- "$@"
-    shifu_run shifu_test_sub_multi_eager_cmd $args
+    shifu_run shifu_test_eager_root_cmd $args
     shifu_assert_zero exit_code $?
     shifu_assert_equal result "$BIN_OPT $ALT_OPT $DEF_OPT" "$expected"
   }
   shifu_parameterize_test run_test \
-  -- two_binaries "-bc leaf-three"         "true true default" \
-  -- value_ends   "-bcd custom leaf-three" "true true custom" \
-  -- separate     "-b -c leaf-three"       "true true default"
+  -- two_binaries "sub-multi-eager -bc leaf-three"         "true true default" \
+  -- value_ends   "sub-multi-eager -bcd custom leaf-three" "true true custom" \
+  -- separate     "sub-multi-eager -b -c leaf-three"       "true true default"
 }
 
 test_shifu_run_eager_bundle_dispatch() {
-  shifu_run shifu_test_sub_multi_eager_cmd -bc leaf-four one two three
+  shifu_run shifu_test_eager_root_cmd sub-multi-eager -bc leaf-four one two three
   shifu_assert_zero exit_code $?
   shifu_assert_equal bin_opt "$BIN_OPT" true
   shifu_assert_equal alt_opt "$ALT_OPT" true

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -957,6 +957,7 @@ shifu_test_sub_multi_eager_cmd() {
   shifu_cmd_subs shifu_test_leaf_three_cmd shifu_test_leaf_four_cmd
 
   shifu_cmd_optb :eager: -b --bin-opt -- BIN_OPT false true "A test eager binary option"
+  shifu_cmd_optb :eager: -c --alt-opt -- ALT_OPT false true "A second test eager binary option"
   shifu_cmd_optd :eager: -d --def-opt -- DEF_OPT default "A test eager default option"
   shifu_cmd_cpte data_one data_two data_three
 }
@@ -1225,6 +1226,95 @@ test_shifu_run_optd_list() {
   -- multiple         shifu_test_list_optd_cmd            "--item a -i b -i c"  "a,b,c," \
   -- default_no_args  shifu_test_list_optd_w_default_cmd  ""                    "zero," \
   -- default_w_args   shifu_test_list_optd_w_default_cmd  "-i one"              "zero,one,"
+}
+
+shifu_test_bundle_cmd() {
+  shifu_cmd_name bundle
+  shifu_cmd_func shifu_test_bundle_func
+  shifu_cmd_optb -a -- BIN_ONE false true "first binary"
+  shifu_cmd_optb -b -- BIN_TWO false true "second binary"
+  shifu_cmd_optb -c -- BIN_THREE false true "third binary"
+  shifu_cmd_optd -o --output -- VALUE_OPT none "value option"
+  shifu_cmd_optd -l --list -- LIST_OPT... "" "list option"
+  shifu_cmd_optb -readonly -- READONLY false true "multi-char single dash"
+  shifu_cmd_argr POS_ONE "positional"
+  shifu_cmd_cpte one two three
+  shifu_cmd_args "remaining"
+}
+
+shifu_test_bundle_func() {
+  bundle_result="$BIN_ONE $BIN_TWO $BIN_THREE $VALUE_OPT $READONLY $POS_ONE"
+}
+
+test_shifu_run_bundle() {
+  run_test() {
+    shifu_test_params @args expected_result expected_parsed -- "$@"
+    shifu_run shifu_test_bundle_cmd $args
+    shifu_assert_zero exit_code $?
+    shifu_assert_equal result "$bundle_result" "$expected_result"
+    shifu_assert_equal parsed "$_shifu_args_parsed" "$expected_parsed"
+  }
+  shifu_parameterize_test run_test \
+  -- bundle_two   "-ab one"       "true true false none false one"   2 \
+  -- bundle_three "-abc one"      "true true true none false one"    2 \
+  -- value_ends   "-abo two one"  "true true false two false one"    3 \
+  -- exact_multi  "-readonly one" "false false false none true one"  2 \
+  -- delimiter    "-- -ab one"    "false false false none false -ab" 2 \
+  -- after_pos    "one -ab"       "true true false none false one"   2
+}
+
+test_shifu_run_bundle_help() {
+  run_test() {
+    shifu_test_params @args -- "$@"
+    actual=$(shifu_run shifu_test_all_options_cmd $args 2>&1)
+    shifu_assert_zero exit_code $?
+    shifu_assert_string_contains help "$actual" "Usage"
+  }
+  shifu_parameterize_test run_test \
+  -- help_last  "-fh" \
+  -- help_first "-hf"
+}
+
+test_shifu_run_bundle_errors() {
+  run_test() {
+    shifu_test_params @args expected_error -- "$@"
+    actual=$(shifu_run shifu_test_all_options_cmd $args 2>&1)
+    shifu_assert_non_zero exit_code $?
+    shifu_assert_string_contains error "$actual" "$expected_error"
+  }
+  shifu_parameterize_test run_test \
+  -- unknown_head "-xy" "Invalid option: -xy" \
+  -- unknown_tail "-fx" "Invalid option: -x"
+}
+
+test_shifu_run_eager_bundle() {
+  run_test() {
+    shifu_test_params @args expected -- "$@"
+    shifu_run shifu_test_sub_multi_eager_cmd $args
+    shifu_assert_zero exit_code $?
+    shifu_assert_equal result "$BIN_OPT $ALT_OPT $DEF_OPT" "$expected"
+  }
+  shifu_parameterize_test run_test \
+  -- two_binaries "-bc leaf-three"         "true true default" \
+  -- value_ends   "-bcd custom leaf-three" "true true custom" \
+  -- separate     "-b -c leaf-three"       "true true default"
+}
+
+test_shifu_run_eager_bundle_dispatch() {
+  shifu_run shifu_test_sub_multi_eager_cmd -bc leaf-four one two three
+  shifu_assert_zero exit_code $?
+  shifu_assert_equal bin_opt "$BIN_OPT" true
+  shifu_assert_equal alt_opt "$ALT_OPT" true
+  shifu_assert_equal positional "$POSITIONAL_ARG" one
+  shifu_assert_equal remaining "$leaf_four_args" "[two] [three]"
+}
+
+test_shifu_run_defer_bundle() {
+  shifu_run shifu_test_root_cmd sub-two leaf-three -gG defer_val one two
+  shifu_assert_zero exit_code $?
+  shifu_assert_equal defer_bin "$DEFER_BIN" true
+  shifu_assert_equal defer_def "$DEFER_DEF" defer_val
+  shifu_assert_equal leaf_three_args "$leaf_three_args" "[one] [two]"
 }
 
 # Testing utilities


### PR DESCRIPTION
This feature comes from the [POSIX utility syntax guidelines](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html#tag_12_02) `#5`:
> One or more options without option-arguments, followed by at most one option that takes an option-argument, should be accepted when grouped behind one '-' delimiter.

E.g. If you have a cli with binary options, `-d` and `-v`, and required option, `-o`, a user should be able to specify them behind a single `-`, i.e. `-dvo out.txt`.