### PR TITLE
Parse attached short option values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [keep a changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-* Bundled short options: a single dash followed by a bundle of short options is expanded, so `-abc` is equivalent to `-a -b -c`. A required or defaulted option may end a bundle and will consume the next argument (`-abo file`). Exact multi-character single-dash flags such as `-readonly` still take precedence, and a help flag in any bundle position will short-circuit to showing the help ([#53])
+* Bundled short options: a single dash followed by a bundle of short options is expanded, so `-abc` is equivalent to `-a -b -c`. A required or defaulted option may end a bundle and will consume the next argument (`-abo file`). Exact multi-character, single-dash flags such as `-readonly` still take precedence, and a help flag in any bundle position will short-circuit to showing the help ([#53])
+* Attached short option values: a option's short flag accepts its value attached directly to it, so `-ofile` is equivalent to `-o file`, including at the tail of a bundle (`-abofile`). The `=` separator now works on short flags (`-o=file`) and on repeatable flags (`-i=one`, `--list=one`) as well, not only on non-repeatable long flags ([#54])
 
 ## [0.2.0] - 2026-07-12
 
@@ -42,6 +43,7 @@ The format is based on [keep a changelog](https://keepachangelog.com/en/1.1.0/),
 [0.2.0]: https://github.com/Ultramann/shifu/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Ultramann/shifu/releases/tag/v0.1.0
 
+[#54]: https://github.com/Ultramann/shifu/pull/54
 [#53]: https://github.com/Ultramann/shifu/pull/53
 [#49]: https://github.com/Ultramann/shifu/pull/49
 [#48]: https://github.com/Ultramann/shifu/pull/48

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [keep a changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 * Bundled short options: a single dash followed by a bundle of short options is expanded, so `-abc` is equivalent to `-a -b -c`. A required or defaulted option may end a bundle and will consume the next argument (`-abo file`). Exact multi-character, single-dash flags such as `-readonly` still take precedence, and a help flag in any bundle position will short-circuit to showing the help ([#53])
-* Attached short option values: a option's short flag accepts its value attached directly to it, so `-ofile` is equivalent to `-o file`, including at the tail of a bundle (`-abofile`). The `=` separator now works on short flags (`-o=file`) and on repeatable flags (`-i=one`, `--list=one`) as well, not only on non-repeatable long flags ([#54])
+* Attached short option values: an option's short flag accepts its value attached directly to it, so `-ofile` is equivalent to `-o file`, including at the tail of a bundle (`-abofile`). The `=` separator now works on short flags (`-o=file`) and on repeatable flags (`-i=one`, `--list=one`) ([#54])
 
 ## [0.2.0] - 2026-07-12
 

--- a/README.md
+++ b/README.md
@@ -585,15 +585,15 @@ Option functions called in a parent command require a mode as the first argument
   cli --config myconfig sub
   ```
 
-##### Positional and remaining argument declaration rules
+##### Passing option values
 
-Positional and remaining argument functions (`shifu_cmd_argr`, `shifu_cmd_args`) can only be used in leaf commands.
+A value option can read its value in a few ways:
 
-The option and argument declaration order in a command function matters:
-1. Help is generated in declaration order
-1. Help strings from parent commands' deferred options are similarly deferred to the end of the generated help string
-1. Positional arguments are parsed in declaration order
-1. Options must be declared before any positional arguments, and positional arguments before remaining arguments
+* From the next argument: `-o value`, `--opt value`
+* Specified with `=`: `-o=value`, `--opt=value`
+* Attached to a short flag: `-ovalue`
+
+These forms work for required, defaulted, and repeatable value options.
 
 ##### End-of-options delimiter (`--`)
 
@@ -628,6 +628,16 @@ shifu_cmd_optd -o --output -- OUTPUT none     "Output file"
 cli -al             # ALL = true, LONG = true, OUTPUT = none
 cli -alo out.txt    # ALL = true, LONG = true, OUTPUT = out.txt
 ```
+
+##### Positional and remaining argument declaration rules
+
+Positional and remaining argument functions (`shifu_cmd_argr`, `shifu_cmd_args`) can only be used in leaf commands.
+
+The option and argument declaration order in a command function matters:
+1. Help is generated in declaration order
+1. Help strings from parent commands' deferred options are similarly deferred to the end of the generated help string
+1. Positional arguments are parsed in declaration order
+1. Options must be declared before any positional arguments, and positional arguments before remaining arguments
 
 ### Completion functions
 

--- a/shifu
+++ b/shifu
@@ -245,6 +245,7 @@ _shifu_run() {
   shifu_cmd="$1"; shift
   shifu_required_variables=""
   shifu_defer_short_bin=""
+  shifu_defer_short_val=""
   while [ $# -ne 0 -a -n "${shifu_cmd_subs:-}" ]; do
     _shifu_parse_args true "$shifu_cur_cmd" "$@"
     shifu_mode=$shifu_mode_cmds_run
@@ -282,6 +283,7 @@ _shifu_parse_args() {
   _shifu_end_of_options=false
   shifu_arg_stmt=""
   shifu_short_bin=""
+  shifu_short_val=""
   shifu_parse_eager="$1"; shifu_cmd="$2"; shift 2
   [ "$shifu_parse_eager" = true ] && shifu_required_variables_eager=""
   shifu_required_positionals=""
@@ -289,6 +291,7 @@ _shifu_parse_args() {
   _shifu_case_inline_deferred
   if [ "$shifu_parse_eager" = false ]; then
     [ -n "${shifu_defer_short_bin:-}" ] && shifu_short_bin="${shifu_short_bin:+$shifu_short_bin|}$shifu_defer_short_bin"
+    [ -n "${shifu_defer_short_val:-}" ] && shifu_short_val="${shifu_short_val:+$shifu_short_val|}$shifu_defer_short_val"
   fi
   _shifu_case_arm_help
   "$shifu_cmd"
@@ -545,7 +548,7 @@ _shifu_cmd_optb() {
       ;;
     $shifu_mode_args_run)
       _shifu_case_arm_begin "$shifu_arg_scope" "$@"
-      _shifu_collect_short_flags "$@"
+      _shifu_collect_short_flags bin "$@"
       shift $shifu_opt_count
       _shifu_guard_arg_order "$1"
       _shifu_var_default "$1" "$2"
@@ -554,7 +557,7 @@ _shifu_cmd_optb() {
         shifu_defer_help="${shifu_defer_help:-}\n    $4\n    Default: $2, set: $3"
       ;;
     $shifu_mode_args_comp)
-      _shifu_collect_short_flags "$@"
+      _shifu_collect_short_flags bin "$@"
       if [ "$shifu_arg_scope" = eager ]; then
         _shifu_opt_comp_eager_parse "$@"
         shift $shifu_opt_count
@@ -580,6 +583,7 @@ _shifu_cmd_optd() {
       ;;
     $shifu_mode_args_run)
       _shifu_case_arm_begin "$shifu_arg_scope" "$@"
+      _shifu_collect_short_flags val "$@"
       shift $shifu_opt_count
       _shifu_guard_arg_order "$1"
       if [ "$shifu_arg_scope" = eager ]; then
@@ -599,6 +603,7 @@ _shifu_cmd_optd() {
       ;;
     $shifu_mode_args_comp)
       shifu_eq_saved_args="$*"
+      _shifu_collect_short_flags val "$@"
       if [ "$shifu_arg_scope" = eager ]; then
         _shifu_opt_comp_eager_parse "$@"
         shift $shifu_opt_count
@@ -625,6 +630,7 @@ _shifu_cmd_optr() {
       ;;
     $shifu_mode_args_run)
       _shifu_case_arm_begin "$shifu_arg_scope" "$@"
+      _shifu_collect_short_flags val "$@"
       shift $shifu_opt_count
       _shifu_guard_arg_order "$1"
       _shifu_var_require "$1"
@@ -634,6 +640,7 @@ _shifu_cmd_optr() {
       ;;
     $shifu_mode_args_comp)
       shifu_eq_saved_args="$*"
+      _shifu_collect_short_flags val "$@"
       if [ "$shifu_arg_scope" = eager ]; then
         _shifu_opt_comp_eager_parse "$@"
         shift $shifu_opt_count
@@ -871,6 +878,7 @@ _shifu_complete_func_args() {
   shifu_comp_remaining_fragment=''
   shifu_comp_arg_stmt=''
   shifu_short_bin=""
+  shifu_short_val=""
   shifu_parse_eager="$1"; shifu_cmd="$2"; shift 2
   _shifu_args_parsed=0
   shifu_comp_eq_patterns=""
@@ -883,6 +891,7 @@ ${shifu_defer_comp_case:-}"
   shifu_last_arg_is_eager=true
   if [ "$shifu_parse_eager" = false ]; then
     [ -n "${shifu_defer_short_bin:-}" ] && shifu_short_bin="${shifu_short_bin:+$shifu_short_bin|}$shifu_defer_short_bin"
+    [ -n "${shifu_defer_short_val:-}" ] && shifu_short_val="${shifu_short_val:+$shifu_short_val|}$shifu_defer_short_val"
   fi
   "$shifu_cmd"
   shifu_comp_past_delimiter=false
@@ -941,12 +950,13 @@ _shifu_append_short() {
 }
 
 _shifu_collect_short_flags() {
+  shifu_csf_kind="$1"; shift
   while [ $# -gt 0 ] && [ "$1" != -- ]; do
     case "$1" in
       -?) if [ "$shifu_arg_scope" = defer ]; then
-            _shifu_append_short shifu_defer_short_bin "${1#-}"
+            _shifu_append_short "shifu_defer_short_$shifu_csf_kind" "${1#-}"
           else
-            _shifu_append_short shifu_short_bin "${1#-}"
+            _shifu_append_short "shifu_short_$shifu_csf_kind" "${1#-}"
           fi ;;
     esac
     shift
@@ -989,7 +999,7 @@ _shifu_case_arm_help() {
 _shifu_case_arm_bundle() {
   shifu_bundle_bin="$shifu_short_bin"
   [ -n "${shifu_help_short:-}" ] && shifu_bundle_bin="${shifu_bundle_bin:+$shifu_bundle_bin|}$shifu_help_short"
-  [ -n "$shifu_bundle_bin" ] || return 0
+  [ -n "${shifu_short_val:-}$shifu_bundle_bin" ] || return 0
   if [ $shifu_mode -eq $shifu_mode_args_comp ]; then
     shifu_bundle_ack=""
     shifu_bundle_default="_shifu_comp_done=true"
@@ -1001,6 +1011,8 @@ _shifu_case_arm_bundle() {
   -[!-]?*)
     _shifu_body=\"\${1#-}\"; _shifu_tail=\"\${_shifu_body#?}\"; _shifu_head=\"\${_shifu_body%\"\$_shifu_tail\"}\"
     case \"\$_shifu_head\" in"
+  [ -n "${shifu_short_val:-}" ] && shifu_case_stmt="$shifu_case_stmt
+    $shifu_short_val) shift; set -- \"-\$_shifu_head\" \"\$_shifu_tail\" \"\$@\"$shifu_bundle_ack ;;"
   [ -n "$shifu_bundle_bin" ] && shifu_case_stmt="$shifu_case_stmt
     $shifu_bundle_bin) shift; set -- \"-\$_shifu_head\" \"-\$_shifu_tail\" \"\$@\"$shifu_bundle_ack ;;"
   shifu_case_stmt="$shifu_case_stmt

--- a/shifu
+++ b/shifu
@@ -973,9 +973,9 @@ _shifu_collect_short_flags() {
 #   _shifu_case_close                     finish the statement (default arm + esac)
 #   _shifu_case_arm_begin <scope> ..      open an option arm: select eager/defer buffer +
 #                                         escaping ($shifu_case_val), emit the flag pattern
-#   _shifu_case_arm_flag <var> <setval>   binary-option body
+#   _shifu_case_arm_flag <var> <set_val>  binary-option body
 #   _shifu_case_arm_value <var>           value-option body (value guard + assign + =-forms)
-#   _shifu_case_arm_append <listvar>      repeatable-option body (value guard + list append)
+#   _shifu_case_arm_append <list_var>     repeatable-option body (value guard + list append + =-forms)
 #   _shifu_case_arm_positional <var>      positional-argument body
 
 _shifu_case_open() {
@@ -1070,12 +1070,13 @@ _shifu_case_arm_flag() {
 _shifu_case_arm_value() {
   _shifu_case_require_value
   _shifu_case_write " $1=$shifu_case_val; shift 2; _shifu_ack_arg 2 ;;"
-  _shifu_case_arm_equals "$1"
+  _shifu_case_arm_equals value "$1"
 }
 
 _shifu_case_arm_append() {
   _shifu_case_require_value
   _shifu_case_write " _shifu_append_list ${1}_LIST \"$shifu_case_val\"; shift 2; _shifu_ack_arg 2 ;;"
+  _shifu_case_arm_equals append "$1"
 }
 
 _shifu_case_positional_open() {
@@ -1112,17 +1113,22 @@ _shifu_case_require_value() {
 }
 
 _shifu_case_arm_equals() {
-  shifu_eq_var="$1"
+  shifu_eq_kind="$1"; shifu_eq_var="$2"
+  if [ "$shifu_eq_kind" = append ]; then
+    shifu_eq_body="_shifu_append_list ${shifu_eq_var}_LIST \"\\\${1#*=}\""
+  else
+    shifu_eq_body="$shifu_eq_var=\\\${1#*=}"
+  fi
   _shifu_set_for_looping shifu_eq_list shifu_eq_saved_args
   for shifu_eq_flag in $shifu_eq_list; do
     case "$shifu_eq_flag" in
       --) break ;;
-      --*)
+      --*|-?)
         if [ "$shifu_case_scope" = eager ]; then
-          _shifu_append_on_new_line shifu_case_stmt "  $shifu_eq_flag=*) $shifu_eq_var=\\\${1#*=}; shift; _shifu_ack_arg ;;"
+          _shifu_append_on_new_line shifu_case_stmt "  $shifu_eq_flag=*) $shifu_eq_body; shift; _shifu_ack_arg ;;"
         else
           shifu_defer_case="$shifu_defer_case
-  $shifu_eq_flag=*) $shifu_eq_var=\\\${1#*=}; shift; _shifu_ack_arg ;;"
+  $shifu_eq_flag=*) $shifu_eq_body; shift; _shifu_ack_arg ;;"
         fi ;;
     esac
   done

--- a/shifu
+++ b/shifu
@@ -548,7 +548,7 @@ _shifu_cmd_optb() {
       ;;
     $shifu_mode_args_run)
       _shifu_case_arm_begin "$shifu_arg_scope" "$@"
-      _shifu_collect_short_flags bin "$@"
+      _shifu_collect_short_bin "$@"
       shift $shifu_opt_count
       _shifu_guard_arg_order "$1"
       _shifu_var_default "$1" "$2"
@@ -557,7 +557,7 @@ _shifu_cmd_optb() {
         shifu_defer_help="${shifu_defer_help:-}\n    $4\n    Default: $2, set: $3"
       ;;
     $shifu_mode_args_comp)
-      _shifu_collect_short_flags bin "$@"
+      _shifu_collect_short_bin "$@"
       if [ "$shifu_arg_scope" = eager ]; then
         _shifu_opt_comp_eager_parse "$@"
         shift $shifu_opt_count
@@ -583,7 +583,7 @@ _shifu_cmd_optd() {
       ;;
     $shifu_mode_args_run)
       _shifu_case_arm_begin "$shifu_arg_scope" "$@"
-      _shifu_collect_short_flags val "$@"
+      _shifu_collect_short_val "$@"
       shift $shifu_opt_count
       _shifu_guard_arg_order "$1"
       if [ "$shifu_arg_scope" = eager ]; then
@@ -603,7 +603,7 @@ _shifu_cmd_optd() {
       ;;
     $shifu_mode_args_comp)
       shifu_eq_saved_args="$*"
-      _shifu_collect_short_flags val "$@"
+      _shifu_collect_short_val "$@"
       if [ "$shifu_arg_scope" = eager ]; then
         _shifu_opt_comp_eager_parse "$@"
         shift $shifu_opt_count
@@ -630,7 +630,7 @@ _shifu_cmd_optr() {
       ;;
     $shifu_mode_args_run)
       _shifu_case_arm_begin "$shifu_arg_scope" "$@"
-      _shifu_collect_short_flags val "$@"
+      _shifu_collect_short_val "$@"
       shift $shifu_opt_count
       _shifu_guard_arg_order "$1"
       _shifu_var_require "$1"
@@ -640,7 +640,7 @@ _shifu_cmd_optr() {
       ;;
     $shifu_mode_args_comp)
       shifu_eq_saved_args="$*"
-      _shifu_collect_short_flags val "$@"
+      _shifu_collect_short_val "$@"
       if [ "$shifu_arg_scope" = eager ]; then
         _shifu_opt_comp_eager_parse "$@"
         shift $shifu_opt_count
@@ -950,17 +950,25 @@ _shifu_append_short() {
 }
 
 _shifu_collect_short_flags() {
-  shifu_csf_kind="$1"; shift
+  shifu_csf_eager="$1"; shifu_csf_defer="$2"; shift 2
   while [ $# -gt 0 ] && [ "$1" != -- ]; do
     case "$1" in
       -?) if [ "$shifu_arg_scope" = defer ]; then
-            _shifu_append_short "shifu_defer_short_$shifu_csf_kind" "${1#-}"
+            _shifu_append_short "$shifu_csf_defer" "${1#-}"
           else
-            _shifu_append_short "shifu_short_$shifu_csf_kind" "${1#-}"
+            _shifu_append_short "$shifu_csf_eager" "${1#-}"
           fi ;;
     esac
     shift
   done
+}
+
+_shifu_collect_short_bin() {
+  _shifu_collect_short_flags shifu_short_bin shifu_defer_short_bin "$@"
+}
+
+_shifu_collect_short_val() {
+  _shifu_collect_short_flags shifu_short_val shifu_defer_short_val "$@"
 }
 
 # case statement codegen: the one set of accessors for shifu_case_stmt / shifu_defer_case

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -445,12 +445,6 @@ test_shifu_run_defer_and_eager_equals_value() {
             EAGER_TEST "custom_eager"
 }
 
-test_shifu_run_short_flag_equals_errors() {
-  actual=$(shifu_run shifu_test_all_options_cmd -d=bad_value 2>&1)
-  shifu_assert_non_zero exit_code $?
-  shifu_assert_string_contains error_message "$actual" "Invalid option"
-}
-
 test_shifu_run_optb_equals_errors() {
   actual=$(shifu_run shifu_test_all_options_cmd \
     -a req_flag_value --option-req req_option_value \
@@ -878,7 +872,13 @@ test_shifu_complete() {
      "one two three" \
   -- subcmds_after_eager_bundle \
      shifu_test_eager_root_cmd "cur_word sub-multi-eager -bc" \
-     "leaf-three leaf-four"
+     "leaf-three leaf-four" \
+  -- positional_after_attached \
+     shifu_test_bundle_cmd "cur_word -otwo" \
+     "one two three" \
+  -- positional_after_attached_bundle \
+     shifu_test_bundle_cmd "cur_word -abotwo" \
+     "one two three"
 }
 
 test_shifu_complete_single_dash_with_config_shows_all_options() {
@@ -1236,6 +1236,9 @@ test_shifu_run_optd_list() {
   -- no_args          shifu_test_list_optd_cmd            ""                    "" \
   -- single           shifu_test_list_optd_cmd            "--item one"          "one," \
   -- multiple         shifu_test_list_optd_cmd            "--item a -i b -i c"  "a,b,c," \
+  -- attached         shifu_test_list_optd_cmd            "-ione -itwo"         "one,two," \
+  -- long_equals      shifu_test_list_optd_cmd            "--item=one"          "one," \
+  -- short_equals     shifu_test_list_optd_cmd            "-i=one"              "one," \
   -- default_no_args  shifu_test_list_optd_w_default_cmd  ""                    "zero," \
   -- default_w_args   shifu_test_list_optd_w_default_cmd  "-i one"              "zero,one,"
 }
@@ -1267,12 +1270,16 @@ test_shifu_run_bundle() {
     shifu_assert_equal parsed "$_shifu_args_parsed" "$expected_parsed"
   }
   shifu_parameterize_test run_test \
-  -- bundle_two   "-ab one"       "true true false none false one"   2 \
-  -- bundle_three "-abc one"      "true true true none false one"    2 \
-  -- value_ends   "-abo two one"  "true true false two false one"    3 \
-  -- exact_multi  "-readonly one" "false false false none true one"  2 \
-  -- delimiter    "-- -ab one"    "false false false none false -ab" 2 \
-  -- after_pos    "one -ab"       "true true false none false one"   2
+  -- bundle_two    "-ab one"       "true true false none false one"   2 \
+  -- bundle_three  "-abc one"      "true true true none false one"    2 \
+  -- value_ends    "-abo two one"  "true true false two false one"    3 \
+  -- exact_multi   "-readonly one" "false false false none true one"  2 \
+  -- delimiter     "-- -ab one"    "false false false none false -ab" 2 \
+  -- after_pos     "one -ab"       "true true false none false one"   2 \
+  -- attached      "-otwo one"     "false false false two false one"  2 \
+  -- attached_tail "-abotwo one"   "true true false two false one"    2 \
+  -- attached_mid  "-aob one"      "true false false b false one"     2 \
+  -- attached_eq   "-o=two one"    "false false false two false one"  2
 }
 
 test_shifu_run_bundle_help() {

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -1279,7 +1279,8 @@ test_shifu_run_bundle() {
   -- attached      "-otwo one"     "false false false two false one"  2 \
   -- attached_tail "-abotwo one"   "true true false two false one"    2 \
   -- attached_mid  "-aob one"      "true false false b false one"     2 \
-  -- attached_eq   "-o=two one"    "false false false two false one"  2
+  -- attached_eq   "-o=two one"    "false false false two false one"  2 \
+  -- value_ends_eq "-abo=two one"  "true true false two false one"    2
 }
 
 test_shifu_run_bundle_help() {


### PR DESCRIPTION
Add support for parsing option values when specified via `=` or directly attached to a short flag. This also works with bundled short options and for repeatable flags.

```sh
shifu_cmd_optb -v -- VERBOSE false true "Turn on verbose output"
shifu_cmd_optr -o -- OUT "File to save to"
```

```sh
cli -oout.txt   # VERBOSE = false OUT = out.txt
cli -o=out.txt  # VERBOSE = false OUT = out.txt
cli -voout.txt  # VERBOSE = true  OUT = out.txt
cli -vo=out.txt # VERBOSE = true  OUT = out.txt
```