### PR TITLE
Parse deferred repeatable options correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [keep a changelog](https://keepachangelog.com/en/1.1.0/),
 * Bundled short options: a single dash followed by a bundle of short options is expanded, so `-abc` is equivalent to `-a -b -c`. A required or defaulted option may end a bundle and will consume the next argument (`-abo file`). Exact multi-character, single-dash flags such as `-readonly` still take precedence, and a help flag in any bundle position will short-circuit to showing the help ([#53])
 * Attached short option values: an option's short flag accepts its value attached directly to it, so `-ofile` is equivalent to `-o file`, including at the tail of a bundle (`-abofile`). The `=` separator now works on short flags (`-o=file`) and on repeatable flags (`-i=one`, `--list=one`) ([#54])
 
+### Fixed
+
+* Repeatable options, `VAR...`, declared with `:defer:` no longer error with "Invalid variable name"; they now accrue values like a repeatable option declared in a leaf command ([#56])
+
 ## [0.2.0] - 2026-07-12
 
 ### Breaking
@@ -43,6 +47,7 @@ The format is based on [keep a changelog](https://keepachangelog.com/en/1.1.0/),
 [0.2.0]: https://github.com/Ultramann/shifu/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Ultramann/shifu/releases/tag/v0.1.0
 
+[#56]: https://github.com/Ultramann/shifu/pull/56
 [#54]: https://github.com/Ultramann/shifu/pull/54
 [#53]: https://github.com/Ultramann/shifu/pull/53
 [#49]: https://github.com/Ultramann/shifu/pull/49

--- a/shifu
+++ b/shifu
@@ -586,20 +586,16 @@ _shifu_cmd_optd() {
       _shifu_collect_short_val "$@"
       shift $shifu_opt_count
       _shifu_guard_arg_order "$1"
-      if [ "$shifu_arg_scope" = eager ]; then
-        _shifu_strip_list_suffix "$1"
-        if [ "$shifu_is_list" = true ]; then
-          _shifu_var_list "$shifu_list_var" "$2"
-          _shifu_case_arm_append "$shifu_list_var"
-        else
-          _shifu_var_default "$1" "$2"
-          _shifu_case_arm_value "$1"
-        fi
+      _shifu_strip_list_suffix "$1"
+      if [ "$shifu_is_list" = true ]; then
+        _shifu_var_list "$shifu_list_var" "$2"
+        _shifu_case_arm_append "$shifu_list_var"
       else
         _shifu_var_default "$1" "$2"
         _shifu_case_arm_value "$1"
-        shifu_defer_help="${shifu_defer_help:-} [$1]\n    $3\n    Default: $2"
       fi
+      [ "$shifu_arg_scope" = defer ] && \
+        shifu_defer_help="${shifu_defer_help:-} [$1]\n    $3\n    Default: $2"
       ;;
     $shifu_mode_args_comp)
       shifu_eq_saved_args="$*"

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -1243,6 +1243,49 @@ test_shifu_run_optd_list() {
   -- default_w_args   shifu_test_list_optd_w_default_cmd  "-i one"              "zero,one,"
 }
 
+shifu_test_defer_list_cmd() {
+  shifu_cmd_name defer-list
+  shifu_cmd_subs shifu_test_scoped_list_leaf_cmd
+
+  shifu_cmd_optd :defer: -l --list -- PARENT_LIST... "" "a deferred repeatable option"
+}
+
+shifu_test_eager_list_cmd() {
+  shifu_cmd_name eager-list
+  shifu_cmd_subs shifu_test_scoped_list_leaf_cmd
+
+  shifu_cmd_optd :eager: -l --list -- PARENT_LIST... "" "an eager repeatable option"
+}
+
+shifu_test_scoped_list_leaf_cmd() {
+  shifu_cmd_name leaf
+  shifu_cmd_func shifu_test_scoped_list_func
+}
+
+shifu_test_scoped_list_func() {
+  result=""
+  while shifu_itr_list PARENT_LIST; do
+    result="$result$PARENT_LIST,"
+  done
+  echo "$result"
+}
+
+test_shifu_run_scoped_repeatable_option() {
+  run_test() {
+    shifu_test_params cmd @cmd_args expected -- "$@"
+    actual=$(shifu_run $cmd $cmd_args 2>&1)
+    shifu_assert_zero exit_code $?
+    shifu_assert_strings_equal output "$expected" "$actual"
+  }
+  shifu_parameterize_test run_test \
+  -- defer_space  shifu_test_defer_list_cmd  "leaf -l one -l two"  "one,two," \
+  -- defer_attch  shifu_test_defer_list_cmd  "leaf -lone -ltwo"    "one,two," \
+  -- defer_eq     shifu_test_defer_list_cmd  "leaf -l=one -l=two"  "one,two," \
+  -- eager_space  shifu_test_eager_list_cmd  "-l one -l two leaf"  "one,two," \
+  -- eager_attch  shifu_test_eager_list_cmd  "-lone -ltwo leaf"    "one,two," \
+  -- eager_eq     shifu_test_eager_list_cmd  "-l=one -l=two leaf"  "one,two,"
+}
+
 shifu_test_bundle_cmd() {
   shifu_cmd_name bundle
   shifu_cmd_func shifu_test_bundle_func


### PR DESCRIPTION
Logic to strip the `...` from a repeated variable name only existed eager mode processing in non-leaf cmds. This caused repeated variables declared with `:defer:` to try to set the variable to the name with the `...`. The PR adjusts the logic to unconditionally strip the `...` from a repeated variable name.

Fixes https://github.com/Ultramann/shifu/issues/55