### PR TITLE
Fix equals value completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [keep a changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 * Repeatable options, `VAR...`, declared with `:defer:` no longer error with "Invalid variable name"; they now accrue values like a repeatable option declared in a leaf command ([#56])
+* Tab completion for option values now works when the value is attached with `=`, so `--opt=<TAB>` and `-o=<TAB>` complete the same values as with space-separated form, in both bash and zsh ([#57])
 
 ## [0.2.0] - 2026-07-12
 
@@ -47,6 +48,7 @@ The format is based on [keep a changelog](https://keepachangelog.com/en/1.1.0/),
 [0.2.0]: https://github.com/Ultramann/shifu/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Ultramann/shifu/releases/tag/v0.1.0
 
+[#57]: https://github.com/Ultramann/shifu/pull/57
 [#56]: https://github.com/Ultramann/shifu/pull/56
 [#54]: https://github.com/Ultramann/shifu/pull/54
 [#53]: https://github.com/Ultramann/shifu/pull/53

--- a/shifu
+++ b/shifu
@@ -760,18 +760,23 @@ Instructions
 
 _shifu_generate_bash_tab_completion() {
   echo "_${shifu_cmd_name}_completion() {
-  current=\"\${COMP_WORDS[\${#COMP_WORDS[@]}-1]}\"
+  local cword=\$COMP_CWORD
+  current=\"\${COMP_WORDS[cword]}\"
+  if [ \"\${COMP_WORDS[cword-1]}\" = \"=\" ]; then
+    full_words=( \"\${COMP_WORDS[@]:1:cword-2}\" )
+    completions=\$($shifu_cmd_name --shifu-complete \"\$current\" \"\${full_words[@]}\")
+    COMPREPLY=( \$(compgen -W \"\$completions\" -- \"\$current\") )
+    return
+  fi
+  if [ \"\$current\" = \"=\" ]; then
+    full_words=( \"\${COMP_WORDS[@]:1:cword-1}\" )
+    completions=\$($shifu_cmd_name --shifu-complete \"\" \"\${full_words[@]}\")
+    prefixed=\"\"
+    for value in \$completions; do prefixed=\"\$prefixed =\$value\"; done
+    COMPREPLY=( \$(compgen -W \"\$prefixed\" -- \"=\") )
+    return
+  fi
   full_words=( \"\${COMP_WORDS[@]:1:\${#COMP_WORDS[@]}-2}\" )
-  case \"\$current\" in
-    -*=*)
-      flag=\"\${current%%=*}\"
-      full_words+=( \"\$flag\" )
-      completions=\$($shifu_cmd_name --shifu-complete \"\${current#*=}\" \"\${full_words[@]}\")
-      prefixed=\"\"
-      for value in \$completions; do prefixed=\"\$prefixed \$flag=\$value\"; done
-      COMPREPLY=( \$(compgen -W \"\$prefixed\" -- \"\$current\") )
-      return ;;
-  esac
   completions=\$($shifu_cmd_name --shifu-complete \"\$current\" \"\${full_words[@]}\")
   case \"\$completions\" in
     SHIFU_COMP_PATH_FILES) COMPREPLY=( \$(compgen -f -- \"\$current\") ) ;;
@@ -781,7 +786,6 @@ _shifu_generate_bash_tab_completion() {
        compopt +o filenames 2>/dev/null ;;
   esac
 }
-COMP_WORDBREAKS=\"\${COMP_WORDBREAKS//=/}\"
 complete -o filenames -F _${shifu_cmd_name}_completion $shifu_cmd_name"
 }
 

--- a/shifu
+++ b/shifu
@@ -759,46 +759,58 @@ Instructions
 }
 
 _shifu_generate_bash_tab_completion() {
-  echo "_${shifu_cmd_name}_completion() {
-  local cword=\$COMP_CWORD
-  current=\"\${COMP_WORDS[cword]}\"
-  if [ \"\${COMP_WORDS[cword-1]}\" = \"=\" ]; then
-    full_words=( \"\${COMP_WORDS[@]:1:cword-2}\" )
-    completions=\$($shifu_cmd_name --shifu-complete \"\$current\" \"\${full_words[@]}\")
-    COMPREPLY=( \$(compgen -W \"\$completions\" -- \"\$current\") )
-    return
-  fi
-  if [ \"\$current\" = \"=\" ]; then
-    full_words=( \"\${COMP_WORDS[@]:1:cword-1}\" )
-    completions=\$($shifu_cmd_name --shifu-complete \"\" \"\${full_words[@]}\")
-    prefixed=\"\"
-    for value in \$completions; do prefixed=\"\$prefixed =\$value\"; done
-    COMPREPLY=( \$(compgen -W \"\$prefixed\" -- \"=\") )
-    return
-  fi
-  full_words=( \"\${COMP_WORDS[@]:1:\${#COMP_WORDS[@]}-2}\" )
-  completions=\$($shifu_cmd_name --shifu-complete \"\$current\" \"\${full_words[@]}\")
+  echo "_shifu_comp_words() {
+  local line words
+  line=\"\${COMP_LINE:0:COMP_POINT}\"
+  # split on whitespace ourselves instead of relying on COMP_WORDS, which
+  # splits on = inconsistently across bash versions
+  read -ra words <<< \"\$line\"
+  case \"\$line\" in
+    *[![:space:]]) shifu_comp_cur=\"\${words[\${#words[@]}-1]}\"
+                   shifu_comp_words=( \"\${words[@]:1:\${#words[@]}-2}\" ) ;;
+    *)             shifu_comp_cur=\"\"
+                   shifu_comp_words=( \"\${words[@]:1}\" ) ;;
+  esac
+  case \"\$shifu_comp_cur\" in
+    -*=*) shifu_comp_words+=( \"\${shifu_comp_cur%%=*}\" )
+          shifu_comp_cur=\"\${shifu_comp_cur#*=}\" ;;
+  esac
+}
+_${shifu_cmd_name}_completion() {
+  local shifu_comp_cur shifu_comp_words completions
+  _shifu_comp_words
+  completions=\$($shifu_cmd_name --shifu-complete \"\$shifu_comp_cur\" \"\${shifu_comp_words[@]}\")
   case \"\$completions\" in
-    SHIFU_COMP_PATH_FILES) COMPREPLY=( \$(compgen -f -- \"\$current\") ) ;;
-    SHIFU_COMP_PATH_DIRS) COMPREPLY=( \$(compgen -d -- \"\$current\") ) ;;
-    SHIFU_COMP_PATH_GLOB:*) COMPREPLY=( \$(compgen -f -X \"!\${completions#SHIFU_COMP_PATH_GLOB:}\" -- \"\$current\") ) ;;
-    *) COMPREPLY=( \$(compgen -W \"\$completions\" -- \"\$current\") )
-       compopt +o filenames 2>/dev/null ;;
+    SHIFU_COMP_PATH_FILES)  COMPREPLY=( \$(compgen -f -- \"\$shifu_comp_cur\") ) ;;
+    SHIFU_COMP_PATH_DIRS)   COMPREPLY=( \$(compgen -d -- \"\$shifu_comp_cur\") ) ;;
+    SHIFU_COMP_PATH_GLOB:*) COMPREPLY=( \$(compgen -f -X \"!\${completions#SHIFU_COMP_PATH_GLOB:}\" \
+                            -- \"\$shifu_comp_cur\") ) ;;
+    *)                      COMPREPLY=( \$(compgen -W \"\$completions\" -- \"\$shifu_comp_cur\") )
+                            compopt +o filenames 2>/dev/null ;;
   esac
 }
 complete -o filenames -F _${shifu_cmd_name}_completion $shifu_cmd_name"
 }
 
 _shifu_generate_zsh_tab_completion() {
-  echo "_${shifu_cmd_name}_completion() {
-  current=\"\${words[\$CURRENT]}\"
-  full_words=( \"\${words[@]:1:\${#words[@]}-2}\" )
-  completions=\$($shifu_cmd_name --shifu-complete \"\$current\" \"\${full_words[@]}\")
+  echo "_shifu_comp_words() {
+  shifu_comp_cur=\"\${words[\$CURRENT]}\"
+  shifu_comp_words=( \"\${words[@]:1:\$((CURRENT-2))}\" )
+  case \"\$shifu_comp_cur\" in
+    -*=*) shifu_comp_words+=( \"\${shifu_comp_cur%%=*}\" )
+          shifu_comp_cur=\"\${shifu_comp_cur#*=}\" ;;
+  esac
+}
+_${shifu_cmd_name}_completion() {
+  local shifu_comp_cur shifu_comp_words completions
+  _shifu_comp_words
+  case \"\${words[\$CURRENT]}\" in -*=*) compset -P '*=' ;; esac
+  completions=\$($shifu_cmd_name --shifu-complete \"\$shifu_comp_cur\" \"\${shifu_comp_words[@]}\")
   case \"\$completions\" in
-    SHIFU_COMP_PATH_FILES) _files -g '*(D)' ;;
-    SHIFU_COMP_PATH_DIRS) _files -g '*(D/)' ;;
+    SHIFU_COMP_PATH_FILES)  _files -g '*(D)' ;;
+    SHIFU_COMP_PATH_DIRS)   _files -g '*(D/)' ;;
     SHIFU_COMP_PATH_GLOB:*) _path_files -g \"\${completions#SHIFU_COMP_PATH_GLOB:}\" ;;
-    *) compadd -q -- \${=completions} ;;
+    *)                      compadd -q -- \${=completions} ;;
   esac
 }
 compdef _${shifu_cmd_name}_completion $shifu_cmd_name"

--- a/shifu
+++ b/shifu
@@ -762,6 +762,16 @@ _shifu_generate_bash_tab_completion() {
   echo "_${shifu_cmd_name}_completion() {
   current=\"\${COMP_WORDS[\${#COMP_WORDS[@]}-1]}\"
   full_words=( \"\${COMP_WORDS[@]:1:\${#COMP_WORDS[@]}-2}\" )
+  case \"\$current\" in
+    -*=*)
+      flag=\"\${current%%=*}\"
+      full_words+=( \"\$flag\" )
+      completions=\$($shifu_cmd_name --shifu-complete \"\${current#*=}\" \"\${full_words[@]}\")
+      prefixed=\"\"
+      for value in \$completions; do prefixed=\"\$prefixed \$flag=\$value\"; done
+      COMPREPLY=( \$(compgen -W \"\$prefixed\" -- \"\$current\") )
+      return ;;
+  esac
   completions=\$($shifu_cmd_name --shifu-complete \"\$current\" \"\${full_words[@]}\")
   case \"\$completions\" in
     SHIFU_COMP_PATH_FILES) COMPREPLY=( \$(compgen -f -- \"\$current\") ) ;;
@@ -771,6 +781,7 @@ _shifu_generate_bash_tab_completion() {
        compopt +o filenames 2>/dev/null ;;
   esac
 }
+COMP_WORDBREAKS=\"\${COMP_WORDBREAKS//=/}\"
 complete -o filenames -F _${shifu_cmd_name}_completion $shifu_cmd_name"
 }
 

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -886,17 +886,37 @@ test_shifu_bash_comp_words() {
   eval "$(shifu_run shifu_test_all_options_cmd --tab-completion bash)"
   run_test() {
     shifu_test_params line cur words -- "$@"
-    COMP_LINE="$line"; COMP_POINT="${#line}"   # cursor at end of line
+    COMP_LINE="$line"; COMP_POINT="${#line}"  # cursor at end of line
     _shifu_comp_words
     shifu_assert_strings_equal cur "$cur" "$shifu_comp_cur"
     shifu_assert_strings_equal words "$words" "${shifu_comp_words[*]}"
   }
   shifu_parameterize_test run_test \
-  -- space_empty  "all -a "              ""    "-a" \
-  -- partial      "all -a fl"            "fl"  "-a" \
-  -- eq_empty     "all --option-def="    ""    "--option-def" \
-  -- eq_partial   "all --option-def=cu"  "cu"  "--option-def" \
-  -- short_eq     "all -d=cu"            "cu"  "-d"
+  -- space_empty     "all -a "                ""      "-a" \
+  -- partial         "all -a part"            "part"  "-a" \
+  -- eq_empty        "all --option-def="      ""      "--option-def" \
+  -- eq_partial      "all --option-def=part"  "part"  "--option-def" \
+  -- short_eq        "all -d=part"            "part"  "-d" \
+  -- short_eq_empty  "all -d="                 ""     "-d"
+}
+
+test_shifu_zsh_comp_words() {
+  [ -n "${ZSH_VERSION:-}" ] || shifu_skip_test
+  eval "$(shifu_run shifu_test_all_options_cmd --tab-completion zsh)"
+  run_test() {
+    shifu_test_params @wordline current expected_cur expected_words -- "$@"
+    eval 'words=( $wordline )'  # array literal hidden from the ash/dash parsers
+    CURRENT=$current
+    _shifu_comp_words
+    shifu_assert_strings_equal cur "$expected_cur" "$shifu_comp_cur"
+    shifu_assert_strings_equal words "$expected_words" "${shifu_comp_words[*]}"
+  }
+  shifu_parameterize_test run_test \
+  -- partial         "all -a part"            3  "part"  "-a" \
+  -- eq_empty        "all --option-def="      2  ""      "--option-def" \
+  -- eq_partial      "all --option-def=part"  2  "part"  "--option-def" \
+  -- short_eq        "all -d=part"            2  "part"  "-d" \
+  -- short_eq_empty  "all -d="                2  ""      "-d"
 }
 
 test_shifu_complete_single_dash_with_config_shows_all_options() {

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -882,7 +882,7 @@ test_shifu_complete() {
 }
 
 test_shifu_bash_comp_words() {
-  [ -n "${BASH_VERSION:-}" ] || return 0
+  [ -n "${BASH_VERSION:-}" ] || shifu_skip_test
   eval "$(shifu_run shifu_test_all_options_cmd --tab-completion bash)"
   run_test() {
     shifu_test_params line cur words -- "$@"
@@ -1399,10 +1399,16 @@ test_shifu_run_defer_bundle() {
 }
 
 # Testing utilities
+shifu_skip_test() {
+  # skip current test, or parameterized case
+  echo "SHIFU_TEST_SKIPPED"
+  exit 0
+}
+
 shifu_parameterize_test() {
   # run test function over many test cases, test cases are separated with --.
   # Test case args that contain multiple words should be passed as a single string
-  # and # unpacked with an @-prefixed name in shifu_test_params for word-splitting.
+  # and unpacked with an @-prefixed name in shifu_test_params for word-splitting
   # Usage:
   # shifu_parameterize_test <test function> \
   # -- <case_name> args...
@@ -1430,16 +1436,21 @@ shifu_parameterize_test() {
       exit $errors
     )
     pt_case_errors=$?
-    if [ $pt_case_errors -eq 0 ]; then
-      pt_passed=$((pt_passed + 1))
-      if [ "${shifu_verbose_tests:-}" = true ]; then
-        printf "   $shifu_green%-4s$shifu_reset%s\n" "+" "$pt_case_name"
-      fi
-    else
-      pt_failed=$((pt_failed + 1))
-      printf "   $shifu_red%-4s$shifu_reset%s\n" "x" "$pt_case_name"
-      [ -n "$pt_case_output" ] && echo "$pt_case_output"
-    fi
+    case "$pt_case_output" in
+      *SHIFU_TEST_SKIPPED*) ;;
+      *)
+        if [ $pt_case_errors -eq 0 ]; then
+          pt_passed=$((pt_passed + 1))
+          if [ "${shifu_verbose_tests:-}" = true ]; then
+            printf "   $shifu_green%-4s$shifu_reset%s\n" "+" "$pt_case_name"
+          fi
+        else
+          pt_failed=$((pt_failed + 1))
+          printf "   $shifu_red%-4s$shifu_reset%s\n" "x" "$pt_case_name"
+          [ -n "$pt_case_output" ] && echo "$pt_case_output"
+        fi
+        ;;
+    esac
     shift $pt_count
   done
   echo "PARAMETERIZED_TEST_COUNTS $pt_passed $pt_failed"
@@ -1597,6 +1608,7 @@ shifu_run_test() {
 shifu_run_test_and_report() {
   # 1: test function
   test_func=$1
+  test_skipped=false
   test_output=$(shifu_run_test "$test_func")
   test_result=$?
   pt_last_line=${test_output##*"
@@ -1613,6 +1625,10 @@ shifu_run_test_and_report() {
       n_failed=$(($n_failed + $pt_failed))
       n_tests=$(($n_tests + $pt_passed + $pt_failed))
       ;;
+    SHIFU_TEST_SKIPPED*)
+      test_output=""
+      test_skipped=true
+      ;;
     *)
       n_tests=$(($n_tests + 1))
       if [ $test_result -eq 0 ]; then
@@ -1622,10 +1638,12 @@ shifu_run_test_and_report() {
       fi
       ;;
   esac
-  if [ $test_result -eq 0 ]; then
-    shifu_report_success "$test_func"
-  else
-    shifu_report_failure "$test_func"
+  if [ "$test_skipped" != true ]; then
+    if [ $test_result -eq 0 ]; then
+      shifu_report_success "$test_func"
+    else
+      shifu_report_failure "$test_func"
+    fi
   fi
   [ -n "$test_output" ] && echo "$test_output"
 }

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -892,12 +892,14 @@ test_shifu_bash_comp_words() {
     shifu_assert_strings_equal words "$words" "${shifu_comp_words[*]}"
   }
   shifu_parameterize_test run_test \
-  -- space_empty     "all -a "                ""      "-a" \
-  -- partial         "all -a part"            "part"  "-a" \
-  -- eq_empty        "all --option-def="      ""      "--option-def" \
-  -- eq_partial      "all --option-def=part"  "part"  "--option-def" \
-  -- short_eq        "all -d=part"            "part"  "-d" \
-  -- short_eq_empty  "all -d="                 ""     "-d"
+  -- space_empty     "all -a "                     ""      "-a" \
+  -- partial         "all -a part"                 "part"  "-a" \
+  -- eq_empty        "all --option-def="           ""      "--option-def" \
+  -- eq_partial      "all --option-def=part"       "part"  "--option-def" \
+  -- short_eq        "all -d=part"                 "part"  "-d" \
+  -- short_eq_empty  "all -d="                     ""      "-d" \
+  -- eq_nested       "all --option-def=a=b"        "a=b"   "--option-def" \
+  -- eq_preceding    "all -a x --option-def=part"  "part"  "-a x --option-def"
 }
 
 test_shifu_zsh_comp_words() {
@@ -912,11 +914,13 @@ test_shifu_zsh_comp_words() {
     shifu_assert_strings_equal words "$expected_words" "${shifu_comp_words[*]}"
   }
   shifu_parameterize_test run_test \
-  -- partial         "all -a part"            3  "part"  "-a" \
-  -- eq_empty        "all --option-def="      2  ""      "--option-def" \
-  -- eq_partial      "all --option-def=part"  2  "part"  "--option-def" \
-  -- short_eq        "all -d=part"            2  "part"  "-d" \
-  -- short_eq_empty  "all -d="                2  ""      "-d"
+  -- partial         "all -a part"                 3  "part"  "-a" \
+  -- eq_empty        "all --option-def="           2  ""      "--option-def" \
+  -- eq_partial      "all --option-def=part"       2  "part"  "--option-def" \
+  -- short_eq        "all -d=part"                 2  "part"  "-d" \
+  -- short_eq_empty  "all -d="                     2  ""      "-d" \
+  -- eq_nested       "all --option-def=a=b"        2  "a=b"   "--option-def" \
+  -- eq_preceding    "all -a x --option-def=part"  4  "part"  "-a x --option-def"
 }
 
 test_shifu_complete_single_dash_with_config_shows_all_options() {

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -754,6 +754,12 @@ test_shifu_complete() {
   -- func_args_positional_enum \
      shifu_test_all_options_cmd "cur_word -f -A flag" \
      "positional arg one" \
+  -- func_args_positional_enum_eq_long \
+     shifu_test_all_options_cmd "cur_word -f --flag-option-req=flag" \
+     "positional arg one" \
+  -- func_args_positional_enum_eq_short \
+     shifu_test_all_options_cmd "cur_word -f -A=flag" \
+     "positional arg one" \
   -- func_args_option_func \
      shifu_test_all_options_cmd "cur_word -f -D" \
      "flag option default" \

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -881,6 +881,24 @@ test_shifu_complete() {
      "one two three"
 }
 
+test_shifu_bash_comp_words() {
+  [ -n "${BASH_VERSION:-}" ] || return 0
+  eval "$(shifu_run shifu_test_all_options_cmd --tab-completion bash)"
+  run_test() {
+    shifu_test_params line cur words -- "$@"
+    COMP_LINE="$line"; COMP_POINT="${#line}"   # cursor at end of line
+    _shifu_comp_words
+    shifu_assert_strings_equal cur "$cur" "$shifu_comp_cur"
+    shifu_assert_strings_equal words "$words" "${shifu_comp_words[*]}"
+  }
+  shifu_parameterize_test run_test \
+  -- space_empty  "all -a "              ""    "-a" \
+  -- partial      "all -a fl"            "fl"  "-a" \
+  -- eq_empty     "all --option-def="    ""    "--option-def" \
+  -- eq_partial   "all --option-def=cu"  "cu"  "--option-def" \
+  -- short_eq     "all -d=cu"            "cu"  "-d"
+}
+
 test_shifu_complete_single_dash_with_config_shows_all_options() {
   shifu_complete_single_dash_options=true
   expected="-f -a -d --option-bin --option-req --option-def -F --flag-option-bin -A --flag-option-req -D --flag-option-def -h --help"


### PR DESCRIPTION
`--opt=<TAB>` and `-o=<TAB>` now complete values, just like the space-separated form, in bash and zsh.

The shifu already completes the space form (`--opt <partial>`), so the shell completion wrappers were changed to rewrite `--opt=<partial>` to the space form before passing through to shifu.

There was a hiccup with bash where it seems `COMP_WORDS` splits on `COMP_WORDBREAKS`, which is both user-configurable and handles `=` differently across bash versions, so it does not consistently tokenize equals value words like `--opt=partial`. Now the bash wrapper manually splits `COMP_LINE` on whitespace, avoiding the inconsistent `COMP_WORDS`.

Fixes https://github.com/Ultramann/shifu/issues/50.