### PR TITLE
Error on unexpected extra args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [keep a changelog](https://keepachangelog.com/en/1.1.0/),
 
 * Repeatable options, `VAR...`, declared with `:defer:` no longer error with "Invalid variable name"; they now accrue values like a repeatable option declared in a leaf command ([#56])
 * Tab completion for option values now works when the value is specified with `=`, so `--opt=<TAB>` and `-o=<TAB>` complete the same values as with space-separated form, in both bash and zsh ([#57])
+* Leaf commands without `shifu_cmd_args` now error on any extra arguments instead of silently forwarding them to the command function via `$@` ([#59])
+* Under `set -u`, leaf commands declaring `shifu_cmd_args` without a preceding positional (`shifu_cmd_argr`) no longer exit with an "unbound variable" error ([#59])
 
 ## [0.2.0] - 2026-07-12
 
@@ -48,6 +50,7 @@ The format is based on [keep a changelog](https://keepachangelog.com/en/1.1.0/),
 [0.2.0]: https://github.com/Ultramann/shifu/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Ultramann/shifu/releases/tag/v0.1.0
 
+[#59]: https://github.com/Ultramann/shifu/pull/59
 [#57]: https://github.com/Ultramann/shifu/pull/57
 [#56]: https://github.com/Ultramann/shifu/pull/56
 [#54]: https://github.com/Ultramann/shifu/pull/54

--- a/README.md
+++ b/README.md
@@ -701,7 +701,7 @@ Option functions called in a parent command require a mode as the first argument
 
 ##### Positional and remaining argument declaration rules
 
-Positional and remaining argument functions (`shifu_cmd_argr`, `shifu_cmd_args`) can only be used in leaf commands.
+Positional and remaining argument functions (`shifu_cmd_argr`, `shifu_cmd_args`) can only be used in leaf commands. A leaf command that does not declare `shifu_cmd_args` rejects extra arguments with an error.
 
 The option and argument declaration order in a command function matters:
 1. Help is generated in declaration order

--- a/README.md
+++ b/README.md
@@ -243,12 +243,12 @@ Arguments and help strings are scoped to each subcommand. Parent commands can al
 
 Below is a demo of [`examples/dispatch`](/examples/dispatch), a CLI with two subcommands, `hello` and `echo`, each with their own arguments. Annotated source code of the CLI can be found in the expandable section below the demo.
 
+<p>
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="/assets/dispatch_demo_dark.gif">
   <img src="/assets/dispatch_demo_light.gif" alt="Dispatch">
 </picture>
-
-<br>
+</p>
 
 <details>
 
@@ -359,12 +359,12 @@ By default, subcommand and option names can be tab completed. Shifu also provide
 
 Below is a demo of [`examples/tab`](/examples/tab) showing tab completion capabilities. Source code and instructions to run the example can be found in the expandable section below the demo.
 
+<p>
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="/assets/tab_demo_dark.gif">
   <img src="/assets/tab_demo_light.gif" alt="Tab completion">
 </picture>
-
-<br>
+</p>
 
 <details>
 

--- a/shifu
+++ b/shifu
@@ -1069,7 +1069,12 @@ _shifu_case_close() {
     eval \"\$shifu_arg_stmt\" ;;"
     shifu_arg_stmt="_shifu_in_remaining=true"
   else
-    _shifu_append_on_new_line shifu_case_stmt "    break;;"
+    if [ "$shifu_parse_eager" = true ]; then
+      _shifu_append_on_new_line shifu_case_stmt "    break;;"
+    else
+      shifu_case_stmt="$shifu_case_stmt
+    echo \"Unexpected argument: \$1\"; _shifu_help \"\$shifu_cmd\" 1 ;;"
+    fi
     shifu_arg_stmt="echo \"Unexpected argument: \$1\"; _shifu_help \"\$shifu_cmd\" 1"
   fi
   _shifu_append_on_new_line shifu_case_stmt "esac"

--- a/shifu
+++ b/shifu
@@ -694,8 +694,8 @@ _shifu_cmd_args() {
   case ${shifu_mode:-0} in
     $shifu_mode_help_run)
       shifu_help_stage=2
-      shifu_help_usage="$shifu_help_usage ...[REMAINING]"
-      shifu_help_arguments="$shifu_help_arguments\n  REMAINING\n    $1"
+      shifu_help_usage="${shifu_help_usage:-} ...[REMAINING]"
+      shifu_help_arguments="${shifu_help_arguments:-}\n  REMAINING\n    $1"
       ;;
     $shifu_mode_args_run)
       [ $shifu_parse_stage -gt 1 ] && _shifu_error "Can only declare remaining arguments once: $1"

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -42,6 +42,7 @@ shifu_test_leaf_one_cmd() {
   shifu_cmd_name leaf-one
   shifu_cmd_help "Test leaf one cmd help"
   shifu_cmd_func shifu_test_leaf_func_one
+  shifu_cmd_args "remaining argument help"
 }
 
 shifu_test_leaf_two_cmd() {
@@ -54,6 +55,7 @@ shifu_test_leaf_three_cmd() {
   shifu_cmd_name leaf-three
   shifu_cmd_help "Test leaf three cmd help"
   shifu_cmd_func shifu_test_leaf_three_func
+  shifu_cmd_args "remaining argument help"
 }
 
 shifu_test_leaf_four_cmd() {
@@ -730,6 +732,13 @@ Options
 
 test_shifu_help_defer() {
   expected='Test leaf three cmd help
+
+Usage
+  leaf-three [OPTIONS] ...[REMAINING]
+
+Arguments
+  REMAINING
+    remaining argument help
 
 Options
   -g, --defer-bin

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -348,10 +348,16 @@ shifu_test_end_of_options_no_args_cmd() {
   shifu_cmd_optd --opt -- OPTION none "value option"
 }
 
-test_shifu_run_end_of_options_no_args_fails() {
-  actual=$(shifu_run shifu_test_end_of_options_no_args_cmd --opt val -- extra 2>&1)
-  shifu_assert_non_zero exit_code $?
-  shifu_assert_string_contains error_message "$actual" "Unexpected argument: extra"
+test_shifu_run_no_args_extra_fails() {
+  run_test() {
+    shifu_test_params @cmd_args expected_error -- "$@"
+    actual=$(shifu_run shifu_test_end_of_options_no_args_cmd $cmd_args 2>&1)
+    shifu_assert_non_zero exit_code $?
+    shifu_assert_string_contains error_message "$actual" "$expected_error"
+  }
+  shifu_parameterize_test run_test \
+  -- bare_extra       "--opt val extra"     "Unexpected argument: extra" \
+  -- after_delimiter  "--opt val -- extra"  "Unexpected argument: extra"
 }
 
 shifu_test_required_options_cmd() {


### PR DESCRIPTION
Previously cli users could pass any number of args and shifu would pass them through to the leaf function via `$@`. However, this args could easily not be picked up in the leaf function, and if they were supposed to be they wouldn't get docs in the help string unless `cmd_args` was used.

This PR causes clis to throw an error if the cli user passes args beyond the declared options and positional args and `cmd_args` isn't declared in the leaf function.

While implementing I found that there was a code path that tried to access a potentially unset variable name and tripped `set -u`. This has been fixed.

Fixes https://github.com/Ultramann/shifu/issues/51.