### PR TITLE
Add optional value command option parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [keep a changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+* `shifu_cmd_opto`: an optional-value option; the flag may be omitted, take a value, or appear bare. The `<bare_value>` argument sets the form: a literal (a bare flag sets the variable to the literal, a value attaches with `=`), `:greedy:` (a bare flag sets no value, `--flag value` and `--flag=value` both set one), or `:strict:` (a value attaches with `=` only, a bare flag sets no value) ([#61])
+* `shifu_bare_opt`: returns 0 when an optional-value flag is passed bare, 1 otherwise ([#61])
+
 ## [0.2.1] - 2026-08-16
 
 ### Added
@@ -53,6 +58,7 @@ The format is based on [keep a changelog](https://keepachangelog.com/en/1.1.0/),
 [0.2.0]: https://github.com/Ultramann/shifu/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Ultramann/shifu/releases/tag/v0.1.0
 
+[#61]: https://github.com/Ultramann/shifu/pull/61
 [#59]: https://github.com/Ultramann/shifu/pull/59
 [#57]: https://github.com/Ultramann/shifu/pull/57
 [#56]: https://github.com/Ultramann/shifu/pull/56

--- a/README.md
+++ b/README.md
@@ -680,12 +680,6 @@ All option and argument functions accept a `variable` argument, the shell variab
     cli --color       # shifu_bare_opt COLOR is true
     ```
 * Detect a bare flag in the leaf function with [`shifu_bare_opt`](#shifu_bare_opt)
-  ```sh
-  cli_func() {
-    shifu_bare_opt COLOR && { list_modes; exit; }
-    colorize "$COLOR"
-  }
-  ```
 
 #### `shifu_cmd_optr`
 * Required option
@@ -845,7 +839,7 @@ Shifu has a few variables that can be set after sourcing to change default behav
   ```
 
 #### `shifu_bare_opt`
-* True when the given variable's [`shifu_cmd_opto`](#shifu_cmd_opto) flag is bare, the flag alone with no value passed
+* True when the given variable's [`shifu_cmd_opto`](#shifu_cmd_opto) flag is bare, the flag is passed alone with no value
     * Holds even for a literal `<bare_value>`, so a bare flag stays distinguishable from the same value passed explicitly
 * Call in the leaf function to detect a bare flag
 * Example

--- a/README.md
+++ b/README.md
@@ -639,7 +639,7 @@ All option and argument functions accept a `variable` argument, the shell variab
   ```sh
   shifu_cmd_opto <flags> -- <variable> <default> <bare_value> <help>
   ```
-* The `<bare_value>` slot sets how the flag takes its value and what a bare flag does; it can be a literal, `:greedy:`, or `:strict:`
+* The `<bare_value>` argument sets how the flag takes its value and what a bare flag does; it can be a literal, `:greedy:`, or `:strict:`
   * a literal (e.g. `always`)
     * a value attaches with `=` only
     * a bare flag sets `<variable>` to the literal
@@ -839,7 +839,7 @@ Shifu has a few variables that can be set after sourcing to change default behav
   ```
 
 #### `shifu_bare_opt`
-* True when the given variable's [`shifu_cmd_opto`](#shifu_cmd_opto) flag is bare, the flag is passed alone with no value
+* Returns 0 when the given variable's [`shifu_cmd_opto`](#shifu_cmd_opto) flag is bare (passed alone with no value), 1 otherwise
     * Holds even for a literal `<bare_value>`, so a bare flag stays distinguishable from the same value passed explicitly
 * Call in the leaf function to detect a bare flag
 * Example

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Shell scripts are great for gluing terminal programs together. But adding subcom
 * [Installation](#installation)
 * [Quickstart](#quickstart)
 * [Argument parsing](#argument-parsing)
-* [Subcommands](#subcommands)
+* [Subcommand dispatching](#subcommand-dispatching)
 * [Tab completion](#tab-completion)
 * [FAQ](#faq)
 * [API](#api)
@@ -106,15 +106,16 @@ The diagram below shows how shifu connects this CLI script to parse the command 
 
 ## Argument parsing
 
-Shifu parses command line arguments into shell variables for the target function. Five argument types are supported, letting CLI authors accept expressive, flexible input from their users.
+Shifu parses command line arguments into shell variables for the target function. Six argument types are supported, letting CLI authors accept expressive, flexible input from their users.
 
-| Type                | Description                                                     | Example   |
-| ------------------- | --------------------------------------------------------------- | --------- |
-| Binary flag         | Sets to one value when the flag is present, another when absent | `-v`      |
-| Option with default | Value set from the option using a default when omitted          | `-o file` |
-| Required option     | Value set from the option that must be provided                 | `-n name` |
-| Positional argument | Value set by position rather than an option                     | `file`    |
-| Remaining arguments | Any extra arguments, collected for the function                 | `a b c`   |
+| Type                  | Description                                                     | Example              |
+| --------------------- | --------------------------------------------------------------- | -------------------- |
+| Binary flag           | Sets to one value when the flag is present, another when absent | `-v`                 |
+| Option with default   | Value set from the option using a default when omitted          | `-o file`            |
+| Optional-value option | Optional value: the flag may take a value or be bare            | `--color[(=| )auto]` |
+| Required option       | Value set from the option that must be provided                 | `-n name`            |
+| Positional argument   | Value set by position rather than an option                     | `file`               |
+| Remaining arguments   | Any extra arguments, collected for the function                 | `a b c`              |
 
 Every example below uses this command.
 
@@ -133,17 +134,18 @@ parse_cmd() {
 option values, bundled short options, interspersed options and arguments, and the
 end-of-options delimiter"
 
-  shifu_cmd_optb -v --verbose -- VERBOSE false true "Verbose output"
-  shifu_cmd_optb -f --force   -- FORCE   false true "Force overwrite"
-  shifu_cmd_optd -o --output  -- OUTPUT  stdout     "Output destination"
-  shifu_cmd_optr -n --name    -- NAME               "Run name"
+  shifu_cmd_optb -v --verbose -- VERBOSE false true  "Verbose output"
+  shifu_cmd_optb -f --force   -- FORCE   false true  "Force overwrite"
+  shifu_cmd_optd -o --output  -- OUTPUT  stdout      "Output destination"
+  shifu_cmd_opto --color      -- COLOR   auto always "When to colorize output"
+  shifu_cmd_optr -n --name    -- NAME                "Run name"
   shifu_cmd_argr SOURCE "File to read"
   shifu_cmd_args "Extra files"
 }
 
 parse_function() {
-  printf 'VERBOSE=%s, FORCE=%s, OUTPUT=%s, NAME=%s, SOURCE=%s, $@=(%s)\n' \
-    "$VERBOSE" "$FORCE" "$OUTPUT" "$NAME" "$SOURCE" "$*"
+  printf 'VERBOSE=%s, FORCE=%s, OUTPUT=%s, COLOR=%s, NAME=%s, SOURCE=%s, $@=(%s)\n' \
+    "$VERBOSE" "$FORCE" "$OUTPUT" "$COLOR" "$NAME" "$SOURCE" "$*"
 }
 
 shifu_run parse_cmd "$@"
@@ -161,7 +163,7 @@ parse --name report in.txt  # NAME=report, long form
 parse --name=report in.txt  # NAME=report, long form with =
 ```
 
-These forms work for any such option, whether required, repeatable, or with a default.
+These forms work for options that are required, repeatable, or have a default. An optional-value option attaches its value with `=` (or a space in its `:greedy:` form); see [`shifu_cmd_opto`](#shifu_cmd_opto).
 
 ### Combining short options
 
@@ -184,13 +186,13 @@ Options may appear before or after positional arguments. Non-option arguments fi
 
 ```sh
 parse -n report in.txt -v
-  # VERBOSE=true, FORCE=false, OUTPUT=stdout, NAME=report, SOURCE=in.txt, $@=()
+  # VERBOSE=true, FORCE=false, OUTPUT=stdout, COLOR=auto, NAME=report, SOURCE=in.txt, $@=()
 parse in.txt -vf -n report
-  # VERBOSE=true, FORCE=true, OUTPUT=stdout, NAME=report, SOURCE=in.txt, $@=()
+  # VERBOSE=true, FORCE=true, OUTPUT=stdout, COLOR=auto, NAME=report, SOURCE=in.txt, $@=()
 parse -n report -v in.txt a.txt b.txt
-  # VERBOSE=true, FORCE=false, OUTPUT=stdout, NAME=report, SOURCE=in.txt, $@=(a.txt b.txt)
+  # VERBOSE=true, FORCE=false, OUTPUT=stdout, COLOR=auto, NAME=report, SOURCE=in.txt, $@=(a.txt b.txt)
 parse -n report in.txt a.txt -v
-  # VERBOSE=false, FORCE=false, OUTPUT=stdout, NAME=report, SOURCE=in.txt, $@=(a.txt -v)
+  # VERBOSE=false, FORCE=false, OUTPUT=stdout, COLOR=auto, NAME=report, SOURCE=in.txt, $@=(a.txt -v)
 ```
 
 ### End-of-options delimiter
@@ -199,16 +201,16 @@ A bare `--` stops option parsing; every argument after it is treated as a non-op
 
 ```sh
 parse -n report -- -v in.txt
-  # VERBOSE=false, FORCE=false, OUTPUT=stdout, NAME=report, SOURCE=-v, $@=(in.txt)
+  # VERBOSE=false, FORCE=false, OUTPUT=stdout, COLOR=auto, NAME=report, SOURCE=-v, $@=(in.txt)
 parse -n report -- -weird.txt
-  # VERBOSE=false, FORCE=false, OUTPUT=stdout, NAME=report, SOURCE=-weird.txt, $@=()
+  # VERBOSE=false, FORCE=false, OUTPUT=stdout, COLOR=auto, NAME=report, SOURCE=-weird.txt, $@=()
 parse -n report -- --output out.txt
-  # VERBOSE=false, FORCE=false, OUTPUT=stdout, NAME=report, SOURCE=--output, $@=(out.txt)
+  # VERBOSE=false, FORCE=false, OUTPUT=stdout, COLOR=auto, NAME=report, SOURCE=--output, $@=(out.txt)
 parse -n report in.txt -- --flag
-  # VERBOSE=false, FORCE=false, OUTPUT=stdout, NAME=report, SOURCE=in.txt, $@=(--flag)
+  # VERBOSE=false, FORCE=false, OUTPUT=stdout, COLOR=auto, NAME=report, SOURCE=in.txt, $@=(--flag)
 ```
 
-## Subcommands
+## Subcommand dispatching
 
 Shifu supports subcommands for grouping related functionality. Use `shifu_cmd_subs` instead of `shifu_cmd_func` to reference subcommand, `_cmd`, functions by name. When called, `shifu_run` recursively matches command line arguments against the names declared with `shifu_cmd_name` in each subcommand. Once a command is found using `shifu_cmd_func`, `shifu_run` calls the function by name as shown in the quickstart.
 

--- a/README.md
+++ b/README.md
@@ -108,14 +108,14 @@ The diagram below shows how shifu connects this CLI script to parse the command 
 
 Shifu parses command line arguments into shell variables for the target function. Six argument types are supported, letting CLI authors accept expressive, flexible input from their users.
 
-| Type                  | Description                                                     | Example              |
-| --------------------- | --------------------------------------------------------------- | -------------------- |
-| Binary flag           | Sets to one value when the flag is present, another when absent | `-v`                 |
-| Option with default   | Value set from the option using a default when omitted          | `-o file`            |
-| Optional-value option | Optional value: the flag may take a value or be bare            | `--color[(=| )auto]` |
-| Required option       | Value set from the option that must be provided                 | `-n name`            |
-| Positional argument   | Value set by position rather than an option                     | `file`               |
-| Remaining arguments   | Any extra arguments, collected for the function                 | `a b c`              |
+| Type                  | Description                                                     | Example               |
+| --------------------- | --------------------------------------------------------------- | --------------------- |
+| Binary flag           | Sets to one value when the flag is present, another when absent | `-v`                  |
+| Option with default   | Value set from the option using a default when omitted          | `-o file`             |
+| Optional-value option | Optional value: the flag may take a value or be bare            | `--color[(=\| )auto]` |
+| Required option       | Value set from the option that must be provided                 | `-n name`             |
+| Positional argument   | Value set by position rather than an option                     | `file`                |
+| Remaining arguments   | Any extra arguments, collected for the function                 | `a b c`               |
 
 Every example below uses this command.
 

--- a/README.md
+++ b/README.md
@@ -567,17 +567,18 @@ These instructions can also be found by running
 
 ### Option and argument functions
 
-There are five option and argument declaration functions:
+There are six option and argument declaration functions:
 
 | Type     | Function         | Parses                       |
 |----------|------------------|------------------------------|
 | Option   | `shifu_cmd_optb` | Binary option                |
 | Option   | `shifu_cmd_optd` | Option with default          |
+| Option   | `shifu_cmd_opto` | Optional-value option        |
 | Option   | `shifu_cmd_optr` | Required option              |
 | Argument | `shifu_cmd_argr` | Required positional argument |
 | Argument | `shifu_cmd_args` | Remaining arguments          |
 
-Option functions (`shifu_cmd_optb`, `shifu_cmd_optd`, `shifu_cmd_optr`) parse flagged arguments into variables. They take one or more flags (e.g. `-v`, `--verbose`) before a required `--` separator, followed by parsing configuration. Argument functions (`shifu_cmd_argr`, `shifu_cmd_args`) parse positional arguments by order of declaration.
+Option functions (`shifu_cmd_optb`, `shifu_cmd_optd`, `shifu_cmd_opto`, `shifu_cmd_optr`) parse flagged arguments into variables. They take one or more flags (e.g. `-v`, `--verbose`) before a required `--` separator, followed by parsing configuration. Argument functions (`shifu_cmd_argr`, `shifu_cmd_args`) parse positional arguments by order of declaration.
 
 All option and argument functions accept a `variable` argument, the shell variable name that will be set when parsing, and a `help` string used in generated help output.
 
@@ -628,6 +629,61 @@ All option and argument functions accept a `variable` argument, the shell variab
     cli                          # ITEM has no values
     cli --item a --item b -i c   # ITEM has values: a, b, c
     ```
+
+#### `shifu_cmd_opto`
+* Optional-value option
+* The flag may be absent, take a value, or appear bare (provided, but with no value)
+* Signature
+  ```sh
+  shifu_cmd_opto <flags> -- <variable> <default> <bare_value> <help>
+  ```
+* The `<bare_value>` slot sets how the flag takes its value and what a bare flag does; it can be a literal, `:greedy:`, or `:strict:`
+  * a literal (e.g. `always`)
+    * a value attaches with `=` only
+    * a bare flag sets `<variable>` to the literal
+    ```sh
+    shifu_cmd_opto --color -- COLOR auto always "When to colorize output"
+    ```
+    ```txt
+    cli               # COLOR=auto
+    cli --color=none  # COLOR=none
+    cli --color none  # COLOR=always, "none" not consumed as the value
+    cli --color       # COLOR=always
+    ```
+  * `:greedy:`
+    * greedily consumes the next argument as the value
+    * a value can also attach with `=`
+      * a value beginning with `-` is never consumed as the next argument; use this form instead
+    * a bare flag sets no value, detect it with `shifu_bare_opt`
+    ```sh
+    shifu_cmd_opto --color -- COLOR auto :greedy: "When to colorize output"
+    ```
+    ```txt
+    cli               # COLOR=auto
+    cli --color=none  # COLOR=none
+    cli --color none  # COLOR=none
+    cli --color       # shifu_bare_opt COLOR is true
+    ```
+  * `:strict:`
+    * strictly never consumes the next argument
+    * a value attaches with `=` only
+    * a bare flag sets no value, detect it with `shifu_bare_opt`
+    ```sh
+    shifu_cmd_opto --color -- COLOR auto :strict: "When to colorize output"
+    ```
+    ```txt
+    cli               # COLOR=auto
+    cli --color=none  # COLOR=none
+    cli --color none  # shifu_bare_opt COLOR is true, "none" not consumed as the value
+    cli --color       # shifu_bare_opt COLOR is true
+    ```
+* Detect a bare flag in the leaf function with [`shifu_bare_opt`](#shifu_bare_opt)
+  ```sh
+  cli_func() {
+    shifu_bare_opt COLOR && { list_modes; exit; }
+    colorize "$COLOR"
+  }
+  ```
 
 #### `shifu_cmd_optr`
 * Required option
@@ -783,6 +839,22 @@ Shifu has a few variables that can be set after sourcing to change default behav
     while shifu_itr_list ITEM; do
       echo "$ITEM"
     done
+  }
+  ```
+
+#### `shifu_bare_opt`
+* True when the given variable's [`shifu_cmd_opto`](#shifu_cmd_opto) flag is bare, the flag alone with no value passed
+    * Holds even for a literal `<bare_value>`, so a bare flag stays distinguishable from the same value passed explicitly
+* Call in the leaf function to detect a bare flag
+* Example
+  ```sh
+  shifu_cmd_opto --color -- COLOR auto :greedy: "When to colorize output"
+
+  run_func() {
+    if shifu_bare_opt COLOR; then
+      list_modes
+      exit 1
+    fi
   }
   ```
 

--- a/examples/parse
+++ b/examples/parse
@@ -10,17 +10,18 @@ parse_cmd() {
 option values, bundled short options, interspersed options and arguments, and the
 end-of-options delimiter"
 
-  shifu_cmd_optb -v --verbose -- VERBOSE false true "Verbose output"
-  shifu_cmd_optb -f --force   -- FORCE   false true "Force overwrite"
-  shifu_cmd_optd -o --output  -- OUTPUT  stdout     "Output destination"
-  shifu_cmd_optr -n --name    -- NAME               "Run name"
+  shifu_cmd_optb -v --verbose -- VERBOSE false true  "Verbose output"
+  shifu_cmd_optb -f --force   -- FORCE   false true  "Force overwrite"
+  shifu_cmd_optd -o --output  -- OUTPUT  stdout      "Output destination"
+  shifu_cmd_opto --color      -- COLOR   auto always "When to colorize output"
+  shifu_cmd_optr -n --name    -- NAME                "Run name"
   shifu_cmd_argr SOURCE "File to read"
   shifu_cmd_args "Extra files"
 }
 
 parse_function() {
-  printf 'VERBOSE=%s, FORCE=%s, OUTPUT=%s, NAME=%s, SOURCE=%s, $@=(%s)\n' \
-    "$VERBOSE" "$FORCE" "$OUTPUT" "$NAME" "$SOURCE" "$*"
+  printf 'VERBOSE=%s, FORCE=%s, OUTPUT=%s, COLOR=%s, NAME=%s, SOURCE=%s, $@=(%s)\n' \
+    "$VERBOSE" "$FORCE" "$OUTPUT" "$COLOR" "$NAME" "$SOURCE" "$*"
 }
 
 shifu_run parse_cmd "$@"

--- a/shifu
+++ b/shifu
@@ -58,7 +58,8 @@
 #     loop with <var> (without ...), each pass sets <var> to the next
 #     accrued value
 #   shifu_bare_opt <var>
-#     true when <var>'s opto flag was passed bare; call in the leaf function
+#     returns 0 when <var>'s opto flag was passed bare, 1 otherwise;
+#     call in the leaf function
 #   shifu_add_cpts <word>...
 #     append words to completions; used inside cptf functions
 #   shifu_less

--- a/shifu
+++ b/shifu
@@ -646,7 +646,7 @@ _shifu_cmd_opto() {
       ;;
     $shifu_mode_args_run)
       _shifu_case_arm_begin "$shifu_arg_scope" "$@"
-      _shifu_collect_short_val "$@"
+      _shifu_collect_opto_short "$@"
       shift $shifu_opt_count
       _shifu_guard_arg_order "$1"
       _shifu_var_default "$1" "$2"
@@ -660,7 +660,7 @@ _shifu_cmd_opto() {
       ;;
     $shifu_mode_args_comp)
       shifu_eq_saved_args="$*"
-      _shifu_collect_short_val "$@"
+      _shifu_collect_opto_short "$@"
       if [ "$shifu_arg_scope" = eager ]; then
         _shifu_opt_comp_eager_parse "$@"
         shift $shifu_opt_count
@@ -1059,6 +1059,22 @@ _shifu_collect_short_bin() {
 
 _shifu_collect_short_val() {
   _shifu_collect_short_flags shifu_short_val shifu_defer_short_val "$@"
+}
+
+_shifu_opto_form() {
+  while [ $# -gt 0 ] && [ "$1" != -- ]; do shift; done
+  shifu_opto_form=$4
+}
+
+# greedy takes a value after a space so it ends a bundle; literal/strict are =-only
+# so they chain like a binary flag
+_shifu_collect_opto_short() {
+  _shifu_opto_form "$@"
+  if [ "$shifu_opto_form" = :greedy: ]; then
+    _shifu_collect_short_val "$@"
+  else
+    _shifu_collect_short_bin "$@"
+  fi
 }
 
 # case statement codegen: the one set of accessors for shifu_case_stmt / shifu_defer_case

--- a/shifu
+++ b/shifu
@@ -57,6 +57,8 @@
 #     iterate args accrued by a repeatable optd flag; call in a while
 #     loop with <var> (without ...), each pass sets <var> to the next
 #     accrued value
+#   shifu_bare_opt <var>
+#     true when <var>'s opto flag was passed bare; call in the leaf function
 #   shifu_add_cpts <word>...
 #     append words to completions; used inside cptf functions
 #   shifu_less
@@ -184,12 +186,6 @@ shifu_cmd_cptp() {
   _shifu_comp_case_arm "shifu_add_cpts \"$shifu_tmp_sentinel\""
 }
 
-shifu_add_cpts() {
-  for completion in "$@"; do
-    _shifu_list_append shifu_completions "$completion"
-  done
-}
-
 shifu_list_delim='#=|=#'
 
 _shifu_append_list() {
@@ -208,6 +204,16 @@ shifu_itr_list() {
   shifu_itr_temp="${shifu_itr_temp#*$shifu_list_delim}"
 }
 
+shifu_bare_opt() {
+  eval "[ \"\${_shifu_bare_$1:-}\" = true ]"
+}
+
+shifu_add_cpts() {
+  for completion in "$@"; do
+    _shifu_list_append shifu_completions "$completion"
+  done
+}
+
 shifu_less() {
   cmd_name() { shifu_cmd_name "$@"; }
   cmd_help() { shifu_cmd_help "$@"; }
@@ -223,8 +229,9 @@ shifu_less() {
   cmd_cpte() { shifu_cmd_cpte "$@"; }
   cmd_cptf() { shifu_cmd_cptf "$@"; }
   cmd_cptp() { shifu_cmd_cptp "$@"; }
-  add_cpts() { shifu_add_cpts "$@"; }
   itr_list() { shifu_itr_list "$@"; }
+  bare_opt() { shifu_bare_opt "$@"; }
+  add_cpts() { shifu_add_cpts "$@"; }
 }
 
 # helpers
@@ -339,6 +346,10 @@ _shifu_parse_args() {
 
 _shifu_ack_arg() {
   _shifu_args_parsed=$((_shifu_args_parsed + ${1:-1}))
+}
+
+_shifu_mark_bare() {
+  eval "_shifu_bare_$1=true"
 }
 
 _shifu_clear_cmd_vars() {
@@ -1163,7 +1174,7 @@ _shifu_case_arm_append() {
 }
 
 _shifu_case_arm_opto_value() {
-  _shifu_case_write ") $1=$2; shift; _shifu_ack_arg ;;"
+  _shifu_case_write ") $1=$2; _shifu_mark_bare $1; shift; _shifu_ack_arg ;;"
   _shifu_case_arm_equals value "$1"
 }
 

--- a/shifu
+++ b/shifu
@@ -650,7 +650,10 @@ _shifu_cmd_opto() {
       shift $shifu_opt_count
       _shifu_guard_arg_order "$1"
       _shifu_var_default "$1" "$2"
-      _shifu_case_arm_opto_value "$1" "$3"
+      case "$3" in
+        :greedy:) _shifu_case_arm_opto_greedy "$1" ;;
+        *) _shifu_case_arm_opto_literal "$1" "$3" ;;
+      esac
       [ "$shifu_arg_scope" = defer ] && \
         shifu_defer_help="${shifu_defer_help:-} [$1]\n    $4\n    Default: $2"
       ;;
@@ -661,11 +664,17 @@ _shifu_cmd_opto() {
         _shifu_opt_comp_eager_parse "$@"
         shift $shifu_opt_count
         _shifu_error_if_invalid_arg_order "$1" $shifu_parse_stage
-        shifu_case_stmt="$shifu_case_stmt)"
+        case "$3" in
+          :greedy:) shifu_case_stmt="$shifu_case_stmt) shift;" ;;
+          *) shifu_case_stmt="$shifu_case_stmt)" ;;
+        esac
       else
         _shifu_opt_build_comp_defer_parse "$@"
         shift $shifu_opt_count
-        shifu_defer_comp_case="${shifu_defer_comp_case:-}) shift ;;"
+        case "$3" in
+          :greedy:) shifu_defer_comp_case="${shifu_defer_comp_case:-}) shift;" ;;
+          *) shifu_defer_comp_case="${shifu_defer_comp_case:-}) shift ;;" ;;
+        esac
       fi
       _shifu_add_equals_comp_case_arms shifu_comp_eq_patterns
       ;;
@@ -1053,19 +1062,20 @@ _shifu_collect_short_val() {
 
 # case statement codegen: the one set of accessors for shifu_case_stmt / shifu_defer_case
 # Nothing else builds those strings by hand
-#   _shifu_case_open                        start a fresh statement (subject read from mode)
-#   _shifu_case_inline_deferred             inline accumulated deferred arms into a leaf statement
-#   _shifu_case_arm_help                    emit the help-flag arm
-#   _shifu_case_arm_bundle                  emit the -XYZ bundle arm, just before -*) so exact arms win
-#   _shifu_case_arm_invalid                 emit the bundle arm + invalid-option arm, open the positional branch
-#   _shifu_case_close                       finish the statement (default arm + esac)
-#   _shifu_case_arm_begin <scope> ..        open an option arm: select eager/defer buffer +
-#                                           escaping ($shifu_case_val), emit the flag pattern
-#   _shifu_case_arm_flag <var> <set_val>    binary-option body
-#   _shifu_case_arm_value <var>             value-option body (value guard + assign + =-forms)
-#   _shifu_case_arm_append <list_var>       repeatable-option body (value guard + list append + =-forms)
-#   _shifu_case_arm_opto_value <var> <lit>  optional-value body (bare sets <lit> + =-forms)
-#   _shifu_case_arm_positional <var>        positional-argument body
+#   _shifu_case_open                          start a fresh statement (subject read from mode)
+#   _shifu_case_inline_deferred               inline accumulated deferred arms into a leaf statement
+#   _shifu_case_arm_help                      emit the help-flag arm
+#   _shifu_case_arm_bundle                    emit the -XYZ bundle arm, just before -*) so exact arms win
+#   _shifu_case_arm_invalid                   emit the bundle arm + invalid-option arm, open the positional branch
+#   _shifu_case_close                         finish the statement (default arm + esac)
+#   _shifu_case_arm_begin <scope> ..          open an option arm: select eager/defer buffer +
+#                                             escaping ($shifu_case_val), emit the flag pattern
+#   _shifu_case_arm_flag <var> <set_val>      binary-option body
+#   _shifu_case_arm_value <var>               value-option body (value guard + assign + =-forms)
+#   _shifu_case_arm_append <list_var>         repeatable-option body (value guard + list append + =-forms)
+#   _shifu_case_arm_opto_literal <var> <lit>  literal-opto body (bare sets <lit> + =-forms)
+#   _shifu_case_arm_opto_greedy <var>         greedy-opto body (next token is the value unless -; + =-forms)
+#   _shifu_case_arm_positional <var>          positional-argument body
 
 _shifu_case_open() {
   if [ $shifu_mode -eq $shifu_mode_args_comp ]; then
@@ -1173,8 +1183,17 @@ _shifu_case_arm_append() {
   _shifu_case_arm_equals append "$1"
 }
 
-_shifu_case_arm_opto_value() {
+_shifu_case_arm_opto_literal() {
   _shifu_case_write ") $1=$2; _shifu_mark_bare $1; shift; _shifu_ack_arg ;;"
+  _shifu_case_arm_equals value "$1"
+}
+
+_shifu_case_arm_opto_greedy() {
+  if [ "$shifu_case_scope" = eager ]; then
+    shifu_case_stmt="$shifu_case_stmt) if [ \$# -ge 2 ] && case \$2 in -*) false ;; *) true ;; esac; then $1=\$2; shift 2; _shifu_ack_arg 2; else _shifu_mark_bare $1; shift; _shifu_ack_arg; fi ;;"
+  else
+    shifu_defer_case="${shifu_defer_case:-}) if [ \\\$# -ge 2 ] && case \\\$2 in -*) false ;; *) true ;; esac; then $1=\\\$2; shift 2; _shifu_ack_arg 2; else _shifu_mark_bare $1; shift; _shifu_ack_arg; fi ;;"
+  fi
   _shifu_case_arm_equals value "$1"
 }
 

--- a/shifu
+++ b/shifu
@@ -33,6 +33,8 @@
 #   shifu_cmd_optd [scope] <flags> -- <var> <default> <help>
 #     option with default value; suffix <var> with ... to make it
 #     repeatable, accruing args into a list (see shifu_itr_list)
+#   shifu_cmd_opto [scope] <flags> -- <var> <default> <bare_value> <help>
+#     optional-value option; a bare flag sets <var> to <bare_value>
 #   shifu_cmd_optr [scope] <flags> -- <var> <help>
 #     required option
 #   shifu_cmd_argr <var> <help>
@@ -146,6 +148,12 @@ shifu_cmd_optd() {
   _shifu_cmd_optd "$@"
 }
 
+shifu_cmd_opto() {
+  _shifu_cmd_get_arg_scope "$@"
+  shift $?
+  _shifu_cmd_opto "$@"
+}
+
 shifu_cmd_optr() {
   _shifu_cmd_get_arg_scope "$@"
   shift $?
@@ -208,6 +216,7 @@ shifu_less() {
   cmd_func() { shifu_cmd_func "$@"; }
   cmd_optb() { shifu_cmd_optb "$@"; }
   cmd_optd() { shifu_cmd_optd "$@"; }
+  cmd_opto() { shifu_cmd_opto "$@"; }
   cmd_optr() { shifu_cmd_optr "$@"; }
   cmd_argr() { shifu_cmd_argr "$@"; }
   cmd_args() { shifu_cmd_args "$@"; }
@@ -616,6 +625,43 @@ _shifu_cmd_optd() {
   esac
 }
 
+_shifu_cmd_opto() {
+  case ${shifu_mode:-0} in
+    $shifu_mode_help_run)
+      _shifu_opt_help_parse "$@"
+      shift $shifu_opt_count
+      _shifu_error_if_invalid_arg_order "$1" $shifu_help_stage
+      shifu_help_options="$shifu_help_options [$1]\n    $4\n    Default: $2"
+      ;;
+    $shifu_mode_args_run)
+      _shifu_case_arm_begin "$shifu_arg_scope" "$@"
+      _shifu_collect_short_val "$@"
+      shift $shifu_opt_count
+      _shifu_guard_arg_order "$1"
+      _shifu_var_default "$1" "$2"
+      _shifu_case_arm_opto_value "$1" "$3"
+      [ "$shifu_arg_scope" = defer ] && \
+        shifu_defer_help="${shifu_defer_help:-} [$1]\n    $4\n    Default: $2"
+      ;;
+    $shifu_mode_args_comp)
+      shifu_eq_saved_args="$*"
+      _shifu_collect_short_val "$@"
+      if [ "$shifu_arg_scope" = eager ]; then
+        _shifu_opt_comp_eager_parse "$@"
+        shift $shifu_opt_count
+        _shifu_error_if_invalid_arg_order "$1" $shifu_parse_stage
+        shifu_case_stmt="$shifu_case_stmt)"
+      else
+        _shifu_opt_build_comp_defer_parse "$@"
+        shift $shifu_opt_count
+        shifu_defer_comp_case="${shifu_defer_comp_case:-}) shift ;;"
+      fi
+      _shifu_add_equals_comp_case_arms shifu_comp_eq_patterns
+      ;;
+    $shifu_mode_opt_names_comp) _shifu_collect_option_names "$@" ;;
+  esac
+}
+
 _shifu_cmd_optr() {
   case ${shifu_mode:-0} in
     $shifu_mode_help_run)
@@ -996,18 +1042,19 @@ _shifu_collect_short_val() {
 
 # case statement codegen: the one set of accessors for shifu_case_stmt / shifu_defer_case
 # Nothing else builds those strings by hand
-#   _shifu_case_open                      start a fresh statement (subject read from mode)
-#   _shifu_case_inline_deferred           inline accumulated deferred arms into a leaf statement
-#   _shifu_case_arm_help                  emit the help-flag arm
-#   _shifu_case_arm_bundle                emit the -XYZ bundle arm, just before -*) so exact arms win
-#   _shifu_case_arm_invalid               emit the bundle arm + invalid-option arm, open the positional branch
-#   _shifu_case_close                     finish the statement (default arm + esac)
-#   _shifu_case_arm_begin <scope> ..      open an option arm: select eager/defer buffer +
-#                                         escaping ($shifu_case_val), emit the flag pattern
-#   _shifu_case_arm_flag <var> <set_val>  binary-option body
-#   _shifu_case_arm_value <var>           value-option body (value guard + assign + =-forms)
-#   _shifu_case_arm_append <list_var>     repeatable-option body (value guard + list append + =-forms)
-#   _shifu_case_arm_positional <var>      positional-argument body
+#   _shifu_case_open                        start a fresh statement (subject read from mode)
+#   _shifu_case_inline_deferred             inline accumulated deferred arms into a leaf statement
+#   _shifu_case_arm_help                    emit the help-flag arm
+#   _shifu_case_arm_bundle                  emit the -XYZ bundle arm, just before -*) so exact arms win
+#   _shifu_case_arm_invalid                 emit the bundle arm + invalid-option arm, open the positional branch
+#   _shifu_case_close                       finish the statement (default arm + esac)
+#   _shifu_case_arm_begin <scope> ..        open an option arm: select eager/defer buffer +
+#                                           escaping ($shifu_case_val), emit the flag pattern
+#   _shifu_case_arm_flag <var> <set_val>    binary-option body
+#   _shifu_case_arm_value <var>             value-option body (value guard + assign + =-forms)
+#   _shifu_case_arm_append <list_var>       repeatable-option body (value guard + list append + =-forms)
+#   _shifu_case_arm_opto_value <var> <lit>  optional-value body (bare sets <lit> + =-forms)
+#   _shifu_case_arm_positional <var>        positional-argument body
 
 _shifu_case_open() {
   if [ $shifu_mode -eq $shifu_mode_args_comp ]; then
@@ -1113,6 +1160,11 @@ _shifu_case_arm_append() {
   _shifu_case_require_value
   _shifu_case_write " _shifu_append_list ${1}_LIST \"$shifu_case_val\"; shift 2; _shifu_ack_arg 2 ;;"
   _shifu_case_arm_equals append "$1"
+}
+
+_shifu_case_arm_opto_value() {
+  _shifu_case_write ") $1=$2; shift; _shifu_ack_arg ;;"
+  _shifu_case_arm_equals value "$1"
 }
 
 _shifu_case_positional_open() {

--- a/shifu
+++ b/shifu
@@ -652,6 +652,7 @@ _shifu_cmd_opto() {
       _shifu_var_default "$1" "$2"
       case "$3" in
         :greedy:) _shifu_case_arm_opto_greedy "$1" ;;
+        :strict:) _shifu_case_arm_opto_strict "$1" ;;
         *) _shifu_case_arm_opto_literal "$1" "$3" ;;
       esac
       [ "$shifu_arg_scope" = defer ] && \
@@ -1075,6 +1076,7 @@ _shifu_collect_short_val() {
 #   _shifu_case_arm_append <list_var>         repeatable-option body (value guard + list append + =-forms)
 #   _shifu_case_arm_opto_literal <var> <lit>  literal-opto body (bare sets <lit> + =-forms)
 #   _shifu_case_arm_opto_greedy <var>         greedy-opto body (next token is the value unless -; + =-forms)
+#   _shifu_case_arm_opto_strict <var>         strict-opto body (bare sets no value + =-forms)
 #   _shifu_case_arm_positional <var>          positional-argument body
 
 _shifu_case_open() {
@@ -1194,6 +1196,11 @@ _shifu_case_arm_opto_greedy() {
   else
     shifu_defer_case="${shifu_defer_case:-}) if [ \\\$# -ge 2 ] && case \\\$2 in -*) false ;; *) true ;; esac; then $1=\\\$2; shift 2; _shifu_ack_arg 2; else _shifu_mark_bare $1; shift; _shifu_ack_arg; fi ;;"
   fi
+  _shifu_case_arm_equals value "$1"
+}
+
+_shifu_case_arm_opto_strict() {
+  _shifu_case_write ") _shifu_mark_bare $1; shift; _shifu_ack_arg ;;"
   _shifu_case_arm_equals value "$1"
 }
 

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -1397,16 +1397,19 @@ shifu_test_bundle_cmd() {
   shifu_cmd_optb -a -- BIN_ONE false true "first binary"
   shifu_cmd_optb -b -- BIN_TWO false true "second binary"
   shifu_cmd_optb -c -- BIN_THREE false true "third binary"
+  shifu_cmd_optb -readonly -- READONLY false true "multi-char single dash"
   shifu_cmd_optd -o --output -- VALUE_OPT none "value option"
   shifu_cmd_optd -l --list -- LIST_OPT... "" "list option"
-  shifu_cmd_optb -readonly -- READONLY false true "multi-char single dash"
+  shifu_cmd_opto -p -- LIT_OPT    none always   "literal opto"
+  shifu_cmd_opto -g -- GREEDY_OPT none :greedy: "greedy opto"
+  shifu_cmd_opto -s -- STRICT_OPT none :strict: "strict opto"
   shifu_cmd_argr POS_ONE "positional"
   shifu_cmd_cpte one two three
   shifu_cmd_args "remaining"
 }
 
 shifu_test_bundle_func() {
-  bundle_result="$BIN_ONE $BIN_TWO $BIN_THREE $VALUE_OPT $READONLY $POS_ONE"
+  bundle_result="$BIN_ONE $BIN_TWO $BIN_THREE $VALUE_OPT $READONLY $LIT_OPT $GREEDY_OPT $STRICT_OPT $POS_ONE"
 }
 
 test_shifu_run_bundle() {
@@ -1418,17 +1421,30 @@ test_shifu_run_bundle() {
     shifu_assert_equal parsed "$_shifu_args_parsed" "$expected_parsed"
   }
   shifu_parameterize_test run_test \
-  -- bundle_two    "-ab one"       "true true false none false one"   2 \
-  -- bundle_three  "-abc one"      "true true true none false one"    2 \
-  -- value_ends    "-abo two one"  "true true false two false one"    3 \
-  -- exact_multi   "-readonly one" "false false false none true one"  2 \
-  -- delimiter     "-- -ab one"    "false false false none false -ab" 2 \
-  -- after_pos     "one -ab"       "true true false none false one"   2 \
-  -- attached      "-otwo one"     "false false false two false one"  2 \
-  -- attached_tail "-abotwo one"   "true true false two false one"    2 \
-  -- attached_mid  "-aob one"      "true false false b false one"     2 \
-  -- attached_eq   "-o=two one"    "false false false two false one"  2 \
-  -- value_ends_eq "-abo=two one"  "true true false two false one"    2
+  -- bundle_two            "-ab one"         "true true false none false none none none one"    2 \
+  -- bundle_three          "-abc one"        "true true true none false none none none one"     2 \
+  -- value_ends            "-abo auto one"   "true true false auto false none none none one"    3 \
+  -- exact_multi           "-readonly one"   "false false false none true none none none one"   2 \
+  -- delimiter             "-- -ab one"      "false false false none false none none none -ab"  2 \
+  -- after_pos             "one -ab"         "true true false none false none none none one"    2 \
+  -- attached              "-oauto one"      "false false false auto false none none none one"  2 \
+  -- attached_tail         "-aboauto one"    "true true false auto false none none none one"    2 \
+  -- attached_mid          "-aob one"        "true false false b false none none none one"      2 \
+  -- attached_eq           "-o=auto one"     "false false false auto false none none none one"  2 \
+  -- value_ends_eq         "-abo=auto one"   "true true false auto false none none none one"    2 \
+  -- opto_lit_bare         "-abp one"        "true true false none false always none none one"  2 \
+  -- opto_lit_equals       "-abp=never one"  "true true false none false never none none one"   2 \
+  -- opto_lit_continue     "-abpc one"       "true true true none false always none none one"   2 \
+  -- opto_lit_first        "-pab one"        "true true false none false always none none one"  2 \
+  -- opto_lit_reparse      "-abpoauto one"   "true true false auto false always none none one"  2 \
+  -- opto_greedy_next      "-abg auto one"   "true true false none false none auto none one"    3 \
+  -- opto_greedy_attached  "-abgauto one"    "true true false none false none auto none one"    2 \
+  -- opto_greedy_equals    "-abg=never one"  "true true false none false none never none one"   2 \
+  -- opto_greedy_bare      "-abg -c one"     "true true true none false none none none one"     3 \
+  -- opto_strict_equals    "-abs=never one"  "true true false none false none none never one"   2 \
+  -- opto_strict_next      "-abs two"        "true true false none false none none none two"    2 \
+  -- opto_strict_continue  "-absc one"       "true true true none false none none none one"     2 \
+  -- opto_strict_first     "-sab one"        "true true false none false none none none one"    2
 }
 
 test_shifu_run_bundle_help() {

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -455,25 +455,26 @@ shifu_test_opto_value_func() {
 
 test_shifu_run_opto_value() {
   run_test() {
-    shifu_test_params @args var value remaining -- "$@"
+    shifu_test_params @args var value bare remaining -- "$@"
     shifu_run shifu_test_opto_value_cmd $args
     shifu_assert_zero exit_code $?
     eval "shifu_assert_equal $var \"\$$var\" \"$value\""
+    shifu_assert_equal bare "$(shifu_bare_opt "$var" && echo yes || echo no)" "$bare"
     shifu_assert_equal remaining "$opto_remaining" "$remaining"
   }
   shifu_parameterize_test run_test \
-  -- literal_absent  ""                 LITERAL  none    ""       \
-  -- literal_bare    "--literal"        LITERAL  always  ""       \
-  -- literal_equals  "--literal=never"  LITERAL  never   ""       \
-  -- literal_space   "--literal one"    LITERAL  always  "[one]"  \
-  -- greedy_absent   ""                 GREEDY   none    ""       \
-  -- greedy_bare     "--greedy"         GREEDY   none    ""       \
-  -- greedy_equals   "--greedy=never"   GREEDY   never   ""       \
-  -- greedy_space    "--greedy one"     GREEDY   one     ""       \
-  -- strict_absent   ""                 STRICT   none    ""       \
-  -- strict_bare     "--strict"         STRICT   none    ""       \
-  -- strict_equals   "--strict=never"   STRICT   never   ""       \
-  -- strict_space    "--strict one"     STRICT   none    "[one]"
+  -- literal_absent  ""                 LITERAL  none    no   ""       \
+  -- literal_bare    "--literal"        LITERAL  always  yes  ""       \
+  -- literal_equals  "--literal=never"  LITERAL  never   no   ""       \
+  -- literal_space   "--literal one"    LITERAL  always  yes  "[one]"  \
+  -- greedy_absent   ""                 GREEDY   none    no   ""       \
+  -- greedy_bare     "--greedy"         GREEDY   none    yes  ""       \
+  -- greedy_equals   "--greedy=never"   GREEDY   never   no   ""       \
+  -- greedy_space    "--greedy one"     GREEDY   one     no   ""       \
+  -- strict_absent   ""                 STRICT   none    no   ""       \
+  -- strict_bare     "--strict"         STRICT   none    yes  ""       \
+  -- strict_equals   "--strict=never"   STRICT   never   no   ""       \
+  -- strict_space    "--strict one"     STRICT   none    yes  "[one]"
 }
 
 test_shifu_run_defer_and_eager_equals_value() {

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -94,9 +94,10 @@ shifu_test_all_options_cmd() {
   shifu_cmd_optb -f -- FLAG_BIN 0 1      "binary flag help"
   shifu_cmd_optr -a -- FLAG_REQ          "required flag help"
   shifu_cmd_optd -d -- FLAG_DEF def_flag "default argument flag help"
-  shifu_cmd_optb --option-bin -- OPTION_BIN 0 1     "binary option help"
-  shifu_cmd_optr --option-req -- OPTION_REQ         "required option help"
-  shifu_cmd_optd --option-def -- OPTION_DEF def_opt "default argument option help"
+  shifu_cmd_optb --option-bin  -- OPTION_BIN 0 1                 "binary option help"
+  shifu_cmd_optr --option-req  -- OPTION_REQ                     "required option help"
+  shifu_cmd_optd --option-def  -- OPTION_DEF def_opt             "default argument option help"
+  shifu_cmd_opto --option-opto -- OPTION_OPTO def_opto bare_opto "optional value option help"
   shifu_cmd_optb -F --flag-option-bin -- FLAG_OPTION_BIN 0 1 "binary flag/option help"
   shifu_cmd_optr -A --flag-option-req -- FLAG_OPTION_REQ     "required flag/option help"
   shifu_cmd_cpte flag option arg
@@ -442,7 +443,9 @@ test_shifu_run_optr_equals_value() {
 shifu_test_opto_value_cmd() {
   shifu_cmd_name colorize
   shifu_cmd_func shifu_test_opto_value_func
-  shifu_cmd_opto --color -- COLOR auto always "when to colorize"
+  shifu_cmd_opto --literal -- LITERAL none always   "literal opto"
+  shifu_cmd_opto --greedy  -- GREEDY  none :greedy: "greedy opto"
+  shifu_cmd_opto --strict  -- STRICT  none :strict: "strict opto"
   shifu_cmd_args "remaining help"
 }
 
@@ -452,17 +455,25 @@ shifu_test_opto_value_func() {
 
 test_shifu_run_opto_value() {
   run_test() {
-    shifu_test_params @args color remaining -- "$@"
+    shifu_test_params @args var value remaining -- "$@"
     shifu_run shifu_test_opto_value_cmd $args
-    shifu_assert_zero   exit_code  $?
-    shifu_assert_equal  color      "$COLOR"           "$color"
-    shifu_assert_equal  remaining  "$opto_remaining"  "$remaining"
+    shifu_assert_zero exit_code $?
+    eval "shifu_assert_equal $var \"\$$var\" \"$value\""
+    shifu_assert_equal remaining "$opto_remaining" "$remaining"
   }
   shifu_parameterize_test run_test \
-  -- absent  ""               auto    ""      \
-  -- bare    "--color"        always  ""      \
-  -- equals  "--color=never"  never   ""      \
-  -- space   "--color one"    always  "[one]"
+  -- literal_absent  ""                 LITERAL  none    ""       \
+  -- literal_bare    "--literal"        LITERAL  always  ""       \
+  -- literal_equals  "--literal=never"  LITERAL  never   ""       \
+  -- literal_space   "--literal one"    LITERAL  always  "[one]"  \
+  -- greedy_absent   ""                 GREEDY   none    ""       \
+  -- greedy_bare     "--greedy"         GREEDY   none    ""       \
+  -- greedy_equals   "--greedy=never"   GREEDY   never   ""       \
+  -- greedy_space    "--greedy one"     GREEDY   one     ""       \
+  -- strict_absent   ""                 STRICT   none    ""       \
+  -- strict_bare     "--strict"         STRICT   none    ""       \
+  -- strict_equals   "--strict=never"   STRICT   never   ""       \
+  -- strict_space    "--strict one"     STRICT   none    "[one]"
 }
 
 test_shifu_run_defer_and_eager_equals_value() {
@@ -718,6 +729,9 @@ Options
   --option-def [OPTION_DEF]
     default argument option help
     Default: def_opt
+  --option-opto [OPTION_OPTO]
+    optional value option help
+    Default: def_opto
   -F, --flag-option-bin
     binary flag/option help
     Default: 0, set: 1
@@ -815,7 +829,7 @@ test_shifu_complete() {
      shifu_test_root_cmd "cur_word -e" "" \
   -- func_args_options \
      shifu_test_all_options_cmd "--op" \
-     "--option-bin --option-req --option-def" \
+     "--option-bin --option-req --option-def --option-opto" \
   -- func_args_flags \
      shifu_test_all_options_cmd "-f" "-f" \
   -- func_args_flag_options \
@@ -823,7 +837,7 @@ test_shifu_complete() {
      "--flag-option-bin --flag-option-req --flag-option-def" \
   -- single_dash_double_dash_only \
      shifu_test_all_options_cmd "-" \
-     "--option-bin --option-req --option-def --flag-option-bin --flag-option-req --flag-option-def --help" \
+     "--option-bin --option-req --option-def --option-opto --flag-option-bin --flag-option-req --flag-option-def --help" \
   -- options_only_when_dash \
      shifu_test_all_options_cmd "cur_word" "positional arg one" \
   -- defer_option_names \
@@ -973,7 +987,7 @@ test_shifu_zsh_comp_words() {
 
 test_shifu_complete_single_dash_with_config_shows_all_options() {
   shifu_complete_single_dash_options=true
-  expected="-f -a -d --option-bin --option-req --option-def -F --flag-option-bin -A --flag-option-req -D --flag-option-def -h --help"
+  expected="-f -a -d --option-bin --option-req --option-def --option-opto -F --flag-option-bin -A --flag-option-req -D --flag-option-def -h --help"
   actual=$(_shifu_complete shifu_test_all_options_cmd --shifu-complete -)
   shifu_assert_strings_equal completion "$expected" "$actual"
 }

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -439,6 +439,32 @@ test_shifu_run_optr_equals_value() {
   -- empty   "--option-req="              ""
 }
 
+shifu_test_opto_value_cmd() {
+  shifu_cmd_name colorize
+  shifu_cmd_func shifu_test_opto_value_func
+  shifu_cmd_opto --color -- COLOR auto always "when to colorize"
+  shifu_cmd_args "remaining help"
+}
+
+shifu_test_opto_value_func() {
+  opto_remaining=$(shifu_test_format_args "$@")
+}
+
+test_shifu_run_opto_value() {
+  run_test() {
+    shifu_test_params @args color remaining -- "$@"
+    shifu_run shifu_test_opto_value_cmd $args
+    shifu_assert_zero   exit_code  $?
+    shifu_assert_equal  color      "$COLOR"           "$color"
+    shifu_assert_equal  remaining  "$opto_remaining"  "$remaining"
+  }
+  shifu_parameterize_test run_test \
+  -- absent  ""               auto    ""      \
+  -- bare    "--color"        always  ""      \
+  -- equals  "--color=never"  never   ""      \
+  -- space   "--color one"    always  "[one]"
+}
+
 test_shifu_run_defer_and_eager_equals_value() {
   run_test() {
     shifu_test_params @cmd_args var expected -- "$@"

--- a/tests/test_shifu.sh
+++ b/tests/test_shifu.sh
@@ -459,7 +459,8 @@ test_shifu_run_opto_value() {
     shifu_run shifu_test_opto_value_cmd $args
     shifu_assert_zero exit_code $?
     eval "shifu_assert_equal $var \"\$$var\" \"$value\""
-    shifu_assert_equal bare "$(shifu_bare_opt "$var" && echo yes || echo no)" "$bare"
+    shifu_bare_opt "$var" && bare_result=yes || bare_result=no
+    shifu_assert_equal bare "$bare_result" "$bare"
     shifu_assert_equal remaining "$opto_remaining" "$remaining"
   }
   shifu_parameterize_test run_test \


### PR DESCRIPTION
This PR adds `shifu_cmd_opto` which allows cli authors to declare options that have an optional value, i.e. the option can be passed in 3 states: absent, with no value (bare), or with a value. This is the first cmd option parser I've had to really intentionally design, as I didn't want it to feel very different from the other `cmd_optx` functions despite wanting to support a wide range of more complex uses. See the [`shifu_cmd_opto`](https://github.com/Ultramann/shifu#shifu_cmd_opto) docs for full api.